### PR TITLE
Fix the reverse player name order

### DIFF
--- a/WebRandomizer/ClientApp/src/components/Multiworld.js
+++ b/WebRandomizer/ClientApp/src/components/Multiworld.js
@@ -47,9 +47,8 @@ export class Multiworld extends Component {
 
         this.connection.on("UpdateClients", async (clients) => {
             if (this.state.sessionData != null) {
-                this.state.sessionData.clients = clients;
                 this.setState({
-                    sessionData: this.state.sessionData
+                    sessionData: { ...this.state.sessionData, clients }
                 });
             }
         });
@@ -178,7 +177,7 @@ export class Multiworld extends Component {
 
             let sessionData = await response.json();
             this.setState({
-                sessionData: sessionData,
+                sessionData: sortWorldsByOrdinal(sessionData),
                 sessionState: 1,
                 sessionInfo: "Session found, connecting to server"
             });
@@ -190,6 +189,12 @@ export class Multiworld extends Component {
                 sessionInfo: "Error trying to establish session: " + err
             });
         }
+    }
+
+    sortWorldsByOrdinal(data) {
+        let worlds = data.seed.worlds;
+        worlds = [...worlds].sort((a, b) => a.worldId - b.worldId);
+        return { ...data, seed: { ...data.seed, worlds } };
     }
 
     async startHub() {


### PR DESCRIPTION
The players are listed in reverse order on the multiworld page which affects their rom files (they have to exchange files with each other) and the resend item feature (they have to pick the name by the reverse mirrored order).

The issue is caused by relying on undefined element order of list attributes in the database model. This pull request implements a quick patch in the form of sorting the list in question, the `worlds` list, client side.