### PR TITLE
Prepare Filler for single player weighting and keysanity

### DIFF
--- a/Randomizer.SMZ3/Config.cs
+++ b/Randomizer.SMZ3/Config.cs
@@ -29,10 +29,11 @@
 
     class Config {
 
+        public bool Multiworld { get; set; } = false;
+        public bool Keysanity { get; set; } = false;
         public Z3Logic Z3Logic { get; set; } = Z3Logic.Nmg;
         public SMLogic SMLogic { get; set; } = SMLogic.Advanced;
         public Difficulty Difficulty { get; set; } = Difficulty.Normal;
-        public bool Keysanity { get; set; } = false;
         public GanonInvincible GanonInvincible { get; set; } = GanonInvincible.BeforeCrystals;
 
     }

--- a/Randomizer.SMZ3/Filler.cs
+++ b/Randomizer.SMZ3/Filler.cs
@@ -41,8 +41,8 @@ namespace Randomizer.SMZ3 {
                 /* We place a PB and Super in Sphere 1 to make sure the filler
                  * doesn't start locking items behind this when there are a
                  * high chance of the trash fill actually making them available */
-                FrontFillItemInWorld(world, ProgressionItems, ItemType.Super, true);
-                FrontFillItemInWorld(world, ProgressionItems, ItemType.PowerBomb, true);
+                FrontFillItemInWorld(world, ProgressionItems, ItemType.Super);
+                FrontFillItemInWorld(world, ProgressionItems, ItemType.PowerBomb);
             }
 
             /* Place moon pearls randomly in the last 50% of items to be placed to move it to a early-mid game item*/
@@ -142,9 +142,9 @@ namespace Randomizer.SMZ3 {
             return assumedItems;
         }
 
-        void FrontFillItemInWorld(World world, List<Item> itemPool, ItemType itemType, bool restrictWorld = false) {
+        void FrontFillItemInWorld(World world, List<Item> itemPool, ItemType itemType) {
             /* Get a shuffled list of available locations to place this item in */
-            Item item = restrictWorld ? itemPool.Get(itemType, world) : itemPool.Get(itemType);
+            Item item = itemPool.Get(itemType, world);
             var availableLocations = world.Locations.Empty().Available(world.Items).Shuffle(Rnd);
             if (availableLocations.Count > 0) {
                 var locationToFill = availableLocations.First();

--- a/Randomizer.SMZ3/Filler.cs
+++ b/Randomizer.SMZ3/Filler.cs
@@ -75,7 +75,6 @@ namespace Randomizer.SMZ3 {
         void InitialFillInOwnWorld(List<Item> items, World world) {
             var swKey = items.Get(ItemType.KeySW);
             world.Locations.Get("Skull Woods - Pinball Room").Item = swKey;
-            world.Items.Add(swKey);
             items.Remove(swKey);
         }
 
@@ -94,7 +93,6 @@ namespace Randomizer.SMZ3 {
                 }
 
                 location.Item = item;
-                location.Region.World.Items.Add(item);
                 itemPool.Remove(item);
             }
         }
@@ -122,7 +120,6 @@ namespace Randomizer.SMZ3 {
             if (location == null)
                 throw new InvalidOperationException($"Tried to front fill {item.Name} in, but no location was available");
             location.Item = item;
-            world.Items.Add(item);
             itemPool.Remove(item);
         }
 
@@ -145,7 +142,6 @@ namespace Randomizer.SMZ3 {
         void FastFill(List<Item> itemPool, IEnumerable<Location> locations) {
             foreach (var (location, item) in locations.Empty().Zip(itemPool, (l, i) => (l, i)).ToList()) {
                 location.Item = item;
-                location.Region.World.Items.Add(item);
                 itemPool.Remove(item);
             }
         }

--- a/Randomizer.SMZ3/Filler.cs
+++ b/Randomizer.SMZ3/Filler.cs
@@ -30,8 +30,10 @@ namespace Randomizer.SMZ3 {
 
                 InitialFillInOwnWorld(dungeon, world);
 
-                var worldLocations = world.Locations.Empty().Shuffle(Rnd);
-                AssumedFill(dungeon, progression, worldLocations, new[] { world });
+                if (Config.Keysanity == false) {
+                    var worldLocations = world.Locations.Empty().Shuffle(Rnd);
+                    AssumedFill(dungeon, progression, worldLocations, new[] { world });
+                }
 
                 /* We place a PB and Super in Sphere 1 to make sure the filler
                  * doesn't start locking items behind this when there are a
@@ -39,6 +41,7 @@ namespace Randomizer.SMZ3 {
                 FrontFillItemInOwnWorld(progression, ItemType.Super, world);
                 FrontFillItemInOwnWorld(progression, ItemType.PowerBomb, world);
 
+                progressionItems.AddRange(dungeon);
                 progressionItems.AddRange(progression);
             }
 

--- a/Randomizer.SMZ3/Filler.cs
+++ b/Randomizer.SMZ3/Filler.cs
@@ -74,17 +74,7 @@ namespace Randomizer.SMZ3 {
 
         void InitialFill(List<Item> itemPool, List<World> worlds) {
             foreach (var world in worlds) {
-
-                /* Place Swamp Palace Key */
-                if (!Config.Keysanity) {
-                    var spKey = itemPool.Find(x => x.World == world && x.Type == ItemType.KeySP);
-                    world.Locations.Get("Swamp Palace - Entrance").Item = spKey;
-                    world.Items.Add(spKey);
-                    itemPool.Remove(spKey);
-                }
-
-                /* Place Skull Woods Pinball Key */
-                var swKey = itemPool.Find(x => x.World == world && x.Type == ItemType.KeySW);
+                var swKey = itemPool.Get(ItemType.KeySW, world);
                 world.Locations.Get("Skull Woods - Pinball Room").Item = swKey;
                 world.Items.Add(swKey);
                 itemPool.Remove(swKey);

--- a/Randomizer.SMZ3/Filler.cs
+++ b/Randomizer.SMZ3/Filler.cs
@@ -56,10 +56,17 @@ namespace Randomizer.SMZ3 {
             GanonTowerFill(junkItems);
 
             var locations = Worlds.SelectMany(x => x.Locations).Empty().Shuffle(Rnd);
+            if (Worlds.Count == 1)
+                locations = ApplyWeighting(locations).ToList();
 
             AssumedFill(progressionItems, new List<Item>(), locations, Worlds);
             FastFill(niceItems, locations);
             FastFill(junkItems, locations);
+        }
+
+        IEnumerable<Location> ApplyWeighting(IEnumerable<Location> locations) {
+            return from location in locations.Select((x, i) => (x, i: i - x.Weight))
+                   orderby location.i select location.x;
         }
 
         void InitialFillInOwnWorld(List<Item> items, World world) {

--- a/Randomizer.SMZ3/Filler.cs
+++ b/Randomizer.SMZ3/Filler.cs
@@ -49,17 +49,19 @@ namespace Randomizer.SMZ3 {
             var niceItems = Worlds.SelectMany(world => Item.CreateNicePool(world)).Shuffle(Rnd);
             var junkItems = Worlds.SelectMany(world => Item.CreateJunkPool(world)).Shuffle(Rnd);
 
-            /* Place moonpearls and morphs in last 25%/50% of the pool so that
-             * they will tend to place in earlier locations.
-             * Prefer morphs being pushed too far up the list than moonpearls,
-             * so start with morph, followed by moonpearls */
-            ReorderItems(progressionItems, ItemType.Morph, n => n - Rnd.Next(n / 4));
-            ReorderItems(progressionItems, ItemType.MoonPearl, n => n - Rnd.Next(n / 2));
+            if (Config.Multiworld == true) {
+                /* Place moonpearls and morphs in last 25%/50% of the pool so that
+                 * they will tend to place in earlier locations.
+                 * Prefer morphs being pushed too far up the list than moonpearls,
+                 * so start with morph, followed by moonpearls */
+                ReorderItems(progressionItems, ItemType.Morph, n => n - Rnd.Next(n / 4));
+                ReorderItems(progressionItems, ItemType.MoonPearl, n => n - Rnd.Next(n / 2));
+            }
 
             GanonTowerFill(junkItems);
 
             var locations = Worlds.SelectMany(x => x.Locations).Empty().Shuffle(Rnd);
-            if (Worlds.Count == 1)
+            if (Config.Multiworld == false)
                 locations = ApplyWeighting(locations).ToList();
 
             AssumedFill(progressionItems, new List<Item>(), locations, Worlds);

--- a/Randomizer.SMZ3/Item.cs
+++ b/Randomizer.SMZ3/Item.cs
@@ -357,14 +357,20 @@ namespace Randomizer.SMZ3 {
 
     }
 
-    static class ItemListExtensions {
+    static class ItemsExtensions {
 
-        public static Item Get(this List<Item> items, ItemType itemType) {
-            return items.Find(i => i.Type == itemType);
+        public static Item Get(this IEnumerable<Item> items, ItemType itemType) {
+            var item = items.FirstOrDefault(i => i.Type == itemType);
+            if (item == null)
+                throw new InvalidOperationException($"Could not find an item of type {itemType}");
+            return item;
         }
 
-        public static Item Get(this List<Item> items, ItemType itemType, World world) {
-            return items.Find(i => i.Type == itemType && i.World == world);
+        public static Item Get(this IEnumerable<Item> items, ItemType itemType, World world) {
+            var item = items.FirstOrDefault(i => i.Type == itemType && i.World == world);
+            if (item == null)
+                throw new InvalidOperationException($"Could not find an item of type {itemType} in world {world.Id}");
+            return item;
         }
 
     }

--- a/Randomizer.SMZ3/Item.cs
+++ b/Randomizer.SMZ3/Item.cs
@@ -8,7 +8,7 @@ using System.Text.RegularExpressions;
 
 namespace Randomizer.SMZ3 {
 
-    public enum ItemType {
+    public enum ItemType : byte {
         Nothing,
 
         MapHC = 0x7F,
@@ -57,6 +57,11 @@ namespace Randomizer.SMZ3 {
         KeyMM = 0xA7,
         KeyTR = 0xAC,
         KeyGT = 0xAD,
+
+        Key = 0x24,
+        Compass = 0x25,
+        BigKey = 0x32,
+        Map = 0x33,
 
         ProgressiveTunic = 0x60,
         ProgressiveShield = 0x5F,
@@ -154,10 +159,14 @@ namespace Randomizer.SMZ3 {
         public World World { get; set; }
 
         static readonly Regex dungeon = new Regex("^(BigKey|Key|Map|Compass)");
+        static readonly Regex bigKey = new Regex("^BigKey");
+        static readonly Regex key = new Regex("^Key");
         static readonly Regex map = new Regex("^Map");
         static readonly Regex compass = new Regex("^Compass");
 
         public bool IsDungeonItem => dungeon.IsMatch(Type.ToString());
+        public bool IsBigKey => bigKey.IsMatch(Type.ToString());
+        public bool IsKey => key.IsMatch(Type.ToString());
         public bool IsMap => map.IsMatch(Type.ToString());
         public bool IsCompass => compass.IsMatch(Type.ToString());
 

--- a/Randomizer.SMZ3/ListExtensions.cs
+++ b/Randomizer.SMZ3/ListExtensions.cs
@@ -6,8 +6,13 @@ namespace Randomizer.SMZ3 {
 
     static class EnumerableExtensions {
 
-        public static List<T> Shuffle<T>(this IEnumerable<T> list, Random rnd) {
-            var copy = new List<T>(list);
+        public static T Random<T>(this IEnumerable<T> source, Random rnd) {
+            var list = source.ToList();
+            return list.ElementAt(rnd.Next(list.Count));
+        }
+
+        public static List<T> Shuffle<T>(this IEnumerable<T> source, Random rnd) {
+            var copy = new List<T>(source);
             var n = copy.Count;
             while ((n -= 1) > 0) {
                 var k = rnd.Next(n + 1);
@@ -16,9 +21,9 @@ namespace Randomizer.SMZ3 {
             return copy;
         }
 
-        public static (IEnumerable<T>, IEnumerable<T>) SplitOff<T>(this IEnumerable<T> list, int count) {
-            var head = list.Take(count);
-            var tail = list.Skip(count);
+        public static (IEnumerable<T>, IEnumerable<T>) SplitOff<T>(this IEnumerable<T> source, int count) {
+            var head = source.Take(count);
+            var tail = source.Skip(count);
             return (head, tail);
         }
 

--- a/Randomizer.SMZ3/ListExtensions.cs
+++ b/Randomizer.SMZ3/ListExtensions.cs
@@ -4,24 +4,17 @@ using System.Linq;
 
 namespace Randomizer.SMZ3 {
 
-    public static class ListExtensions {
+    static class EnumerableExtensions {
 
-        public static List<T> Shuffle<T>(this IList<T> list, Random random) {
-            var shuffledList = new List<T>(list);
-            var n = shuffledList.Count;
-            while (n > 1) {
-                n -= 1;
-                var k = random.Next(n + 1);
-                var value = shuffledList[k];
-                shuffledList[k] = shuffledList[n];
-                shuffledList[n] = value;
+        public static List<T> Shuffle<T>(this IEnumerable<T> list, Random rnd) {
+            var copy = new List<T>(list);
+            var n = copy.Count;
+            while ((n -= 1) > 0) {
+                var k = rnd.Next(n + 1);
+                (copy[n], copy[k]) = (copy[k], copy[n]);
             }
-            return shuffledList;
+            return copy;
         }
-
-    }
-
-    public static class EnumerableExtensions {
 
         public static (IEnumerable<T>, IEnumerable<T>) SplitOff<T>(this IEnumerable<T> list, int count) {
             var head = list.Take(count);

--- a/Randomizer.SMZ3/Location.cs
+++ b/Randomizer.SMZ3/Location.cs
@@ -25,12 +25,17 @@ namespace Randomizer.SMZ3 {
         public string Name { get; set; }
         public LocationType Type { get; set; }
         public int Address { get; set; }
-        public Region Region { get; set; }
         public Item Item { get; set; }
+        public Region Region { get; set; }
+
+        public int Weight {
+            get { return weight ?? Region.Weight; }
+        }
 
         readonly Requirement canAccess;
         Verification alwaysAllow;
         Verification allow;
+        int? weight;
 
         public ItemType ItemType {
             get { return Item?.Type ?? ItemType.Nothing; }
@@ -49,6 +54,11 @@ namespace Randomizer.SMZ3 {
             canAccess = access;
             alwaysAllow = (item, items) => false;
             allow = (item, items) => true;
+        }
+
+        public Location Weighted(int? weight) {
+            this.weight = weight;
+            return this;
         }
 
         public Location AlwaysAllow(Verification allow) {

--- a/Randomizer.SMZ3/Location.cs
+++ b/Randomizer.SMZ3/Location.cs
@@ -74,41 +74,42 @@ namespace Randomizer.SMZ3 {
         }
     }
 
-    public static class LocationListExtensions {
+    static class LocationsExtensions {
 
-        internal static Location Get(this List<Location> locations, string name) {
-            var location = locations.Find(l => l.Name == name);
+        public static Location Get(this IEnumerable<Location> locations, string name) {
+            var location = locations.FirstOrDefault(l => l.Name == name);
             if (location == null)
                 throw new ArgumentException($"Could not find location name {name}", nameof(name));
             return location;
         }
 
-        internal static List<Location> Empty(this List<Location> locations) {
-            return locations.Where(l => l.Item == null).ToList();
+        public static IEnumerable<Location> Empty(this IEnumerable<Location> locations) {
+            return locations.Where(l => l.Item == null);
         }
 
-        internal static List<Location> AvailableWithinWorld(this List<Location> locations, List<Item> items) {
-            var availableLocations = new List<Location>();
-            foreach (var world in locations.Select(x => x.Region.World).Distinct()) {
-                var progression = new Progression(items.Where(i => i.World == world));
-                availableLocations.AddRange(locations.Where(l => l.Region.World == world && l.Available(progression)).ToList());
-            }
-            return availableLocations;
+        public static IEnumerable<Location> Filled(this IEnumerable<Location> locations) {
+            return locations.Where(l => l.Item != null);
         }
 
-        internal static List<Location> Available(this List<Location> locations, List<Item> items) {
+        public static IEnumerable<Location> AvailableWithinWorld(this IEnumerable<Location> locations, IEnumerable<Item> items) {
+            return locations.Select(x => x.Region.World).Distinct().SelectMany(world =>
+                locations.Where(l => l.Region.World == world).Available(items.Where(i => i.World == world)));
+        }
+
+        public static IEnumerable<Location> Available(this IEnumerable<Location> locations, IEnumerable<Item> items) {
             var progression = new Progression(items);
-            return locations.Where(l => l.Available(progression)).ToList();
+            return locations.Where(l => l.Available(progression));
         }
 
-        internal static List<Location> CanFillWithinWorld(this List<Location> locations, Item item, List<Item> items) {
+        public static IEnumerable<Location> CanFillWithinWorld(this IEnumerable<Location> locations, Item item, IEnumerable<Item> items) {
             var itemWorldProgression = new Progression(items.Where(i => i.World == item.World).Append(item));
-            var availableLocations = new List<Location>();
-            foreach (var world in locations.Select(x => x.Region.World).Distinct()) {
+            return locations.Select(x => x.Region.World).Distinct().SelectMany(world => {
                 var progression = new Progression(items.Where(i => i.World == world));
-                availableLocations.AddRange(locations.Where(l => l.Region.World == world && l.CanFill(item, progression) && item.World.Locations.Find(ll => ll.Id == l.Id).Available(itemWorldProgression)).ToList());
-            }
-            return availableLocations;
+                return locations.Where(l =>
+                    l.Region.World == world &&
+                    l.CanFill(item, progression) &&
+                    item.World.Locations.Find(ll => ll.Id == l.Id).Available(itemWorldProgression));
+            });
         }
 
     }

--- a/Randomizer.SMZ3/Location.cs
+++ b/Randomizer.SMZ3/Location.cs
@@ -10,6 +10,7 @@ namespace Randomizer.SMZ3 {
         Pedestal,
         Ether,
         Bombos,
+        NotInDungeon,
 
         Visible,
         Chozo,

--- a/Randomizer.SMZ3/Patch.cs
+++ b/Randomizer.SMZ3/Patch.cs
@@ -214,18 +214,20 @@ namespace Randomizer.SMZ3 {
                     }
                 }
                 patches.Add((Z3Snes(location.Address), new byte[] { (byte)(location.Id - 256) }));
-                patches.Add(ItemTablePatch(location, GetZ3ItemId(location.Item.Type)));
+                patches.Add(ItemTablePatch(location, GetZ3ItemId(location)));
             }
         }
 
-        byte GetZ3ItemId(ItemType item) {
-            var value = (int)item switch {
-                var id when id >= 0x72 && id <= 0x7F => 0x33,
-                var id when id >= 0x82 && id <= 0x8D => 0x25,
-                var id when id >= 0x92 && id <= 0x9D => 0x32,
-                var id when id >= 0xA0 && id <= 0xAD => 0x24,
-                var id => id,
-            };
+        byte GetZ3ItemId(Location location) {
+            var item = location.Item;
+            var value = location.Type == LocationType.NotInDungeon ||
+                !(item.IsDungeonItem && location.Region.IsRegionItem(item)) ? item.Type : item switch {
+                    _ when item.IsKey => Key,
+                    _ when item.IsBigKey => BigKey,
+                    _ when item.IsMap => Map,
+                    _ when item.IsCompass => Compass,
+                    _ => throw new InvalidOperationException($"Tried replacing {item} with a dungeon region item"),
+                };
             return (byte)value;
         }
 

--- a/Randomizer.SMZ3/Patch.cs
+++ b/Randomizer.SMZ3/Patch.cs
@@ -307,7 +307,7 @@ namespace Randomizer.SMZ3 {
                     prize == Fairy ? Heart : prize);
             }
 
-            var prizes = pool.ToList().Shuffle(rnd).Cast<byte>();
+            var prizes = pool.Shuffle(rnd).Cast<byte>();
 
             /* prize pack drop order */
             (bytes, prizes) = prizes.SplitOff(prizePackItems);

--- a/Randomizer.SMZ3/Playthrough.cs
+++ b/Randomizer.SMZ3/Playthrough.cs
@@ -21,7 +21,7 @@ namespace Randomizer.SMZ3 {
             while (items.Count < totalItemCount) {
                 var sphere = new Dictionary<string, string>();
 
-                var allLocations = worlds.SelectMany(w => w.Locations.Available(items.Where(i => i.World == w).ToList()));
+                var allLocations = worlds.SelectMany(w => w.Locations.Available(items.Where(i => i.World == w)));
                 var newLocations = allLocations.Except(locations).ToList();
                 var newItems = newLocations.Select(l => l.Item).ToList();
                 locations.AddRange(newLocations);

--- a/Randomizer.SMZ3/Randomizer.cs
+++ b/Randomizer.SMZ3/Randomizer.cs
@@ -24,15 +24,19 @@ namespace Randomizer.SMZ3 {
                 logic = options["logic"] switch {
                     "casual" => SMLogic.Casual,
                     "tournament" => SMLogic.Advanced,
-                    _ => SMLogic.Advanced
+                    _ => SMLogic.Advanced,
                 };
             }
 
-            var config = new Config { SMLogic = logic };
-            var worlds = new List<World>();
+            var players = options.ContainsKey("worlds") ? int.Parse(options["worlds"]) : 1;
 
-            int players = options.ContainsKey("worlds") ? int.Parse(options["worlds"]) : 1;
-            for (int p = 0; p < players; p++) {
+            var config = new Config {
+                Multiworld = players > 1,
+                SMLogic = logic,
+            };
+
+            var worlds = new List<World>();
+            for (var p = 0; p < players; p++) {
                 worlds.Add(new World(config, options[$"player-{p}"], p, new HexGuid()));
             }
 
@@ -48,11 +52,11 @@ namespace Randomizer.SMZ3 {
                 Game = "SMAlttP Combo Randomizer",
                 Logic = logic.ToString(),
                 Playthrough = spheres,
-                Worlds = new List<IWorldData>()
+                Worlds = new List<IWorldData>(),
             };
 
             /* Make sure RNG is the same when applying patches to the ROM to have consistent RNG for seed identifer etc */
-            int patchSeed = randoRnd.Next();
+            var patchSeed = randoRnd.Next();
             foreach (var world in worlds) {
                 var patchRnd = new Random(patchSeed);
                 var patch = new Patch(world, worlds, seedData.Guid, randoSeed, patchRnd);
@@ -60,7 +64,7 @@ namespace Randomizer.SMZ3 {
                     Id = world.Id,
                     Guid = world.Guid,
                     Player = world.Player,
-                    Patches = patch.Create(config)
+                    Patches = patch.Create(config),
                 };
 
                 seedData.Worlds.Add(worldData);

--- a/Randomizer.SMZ3/Region.cs
+++ b/Randomizer.SMZ3/Region.cs
@@ -47,8 +47,12 @@ namespace Randomizer.SMZ3 {
             World = world;
         }
 
+        public bool IsRegionItem(Item item) {
+            return RegionItems.Contains(item.Type);
+        }
+
         public virtual bool CanFill(Item item) {
-            return Config.Keysanity || !item.IsDungeonItem || RegionItems.Contains(item.Type);
+            return Config.Keysanity || !item.IsDungeonItem || IsRegionItem(item);
         }
 
         public virtual bool CanEnter(Progression items) {

--- a/Randomizer.SMZ3/Region.cs
+++ b/Randomizer.SMZ3/Region.cs
@@ -37,6 +37,7 @@ namespace Randomizer.SMZ3 {
         public virtual string Area { get; }
         public List<Location> Locations { get; set; }
         public World World { get; set; }
+        public int Weight { get; set; } = 0;
 
         protected Config Config { get; set; }
         protected IList<ItemType> RegionItems { get; set; } = new List<ItemType>();

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Green.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Green.cs
@@ -9,6 +9,8 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
         public override string Area => "Brinstar";
 
         public Green(World world, Config config) : base(world, config) {
+            Weight = -6;
+
             Locations = new List<Location> {
                 new Location(this, 13, 0xC784AC, LocationType.Chozo, "Power Bomb (green Brinstar bottom)", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Pink.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Pink.cs
@@ -9,6 +9,8 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
         public override string Area => "Brinstar";
 
         public Pink(World world, Config config) : base(world, config) {
+            Weight = -4;
+
             Locations = new List<Location> {
                 new Location(this, 14, 0xC784E4, LocationType.Chozo, "Super Missile (pink Brinstar)", Logic switch {
                     _ => new Requirement(items => items.CanPassBombPassages() && items.Super)

--- a/Randomizer.SMZ3/Regions/Zelda/GanonTower.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/GanonTower.cs
@@ -148,13 +148,15 @@ namespace Randomizer.SMZ3.Regions.Zelda {
         }
 
         public override bool CanFill(Item item) {
-            /* Never cross-world fill GT */
-            if (item.World != World)
-                return false;
+            if (Config.Multiworld == true) {
+                /* Never cross-world fill GT */
+                if (item.World != World)
+                    return false;
 
-            /* TODO: Temporary fix, disallow progression items completely from GT */
-            if (item.Progression)
-                return false;
+                /* TODO: Temporary fix, disallow progression items completely from GT */
+                if (item.Progression)
+                    return false;
+            }
 
             return base.CanFill(item);
         }

--- a/Randomizer.SMZ3/Regions/Zelda/HyruleCastle.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/HyruleCastle.cs
@@ -27,9 +27,9 @@ namespace Randomizer.SMZ3.Regions.Zelda {
                     items => items.KeyHC),
                 new Location(this, 256+98, 0xEB09, LocationType.Regular, "Hyrule Castle - Zelda's Cell",
                     items => items.KeyHC),
-                new Location(this, 256+99, 0x2DF45, LocationType.Regular, "Link's Uncle")
+                new Location(this, 256+99, 0x2DF45, LocationType.NotInDungeon, "Link's Uncle")
                     .Allow((item, items) => Config.Keysanity || !item.IsDungeonItem).Weighted(sphereOne),
-                new Location(this, 256+100, 0xE971, LocationType.Regular, "Secret Passage")
+                new Location(this, 256+100, 0xE971, LocationType.NotInDungeon, "Secret Passage")
                     .Allow((item, items) => Config.Keysanity || !item.IsDungeonItem).Weighted(sphereOne),
             };
         }

--- a/Randomizer.SMZ3/Regions/Zelda/HyruleCastle.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/HyruleCastle.cs
@@ -11,8 +11,9 @@ namespace Randomizer.SMZ3.Regions.Zelda {
         public HyruleCastle(World world, Config config) : base(world, config) {
             RegionItems = new[] { KeyHC, MapHC };
 
+            var sphereOne = -10;
             Locations = new List<Location> {
-                new Location(this, 256+91, 0xEA79, LocationType.Regular, "Sanctuary"),
+                new Location(this, 256+91, 0xEA79, LocationType.Regular, "Sanctuary").Weighted(sphereOne),
                 new Location(this, 256+92, 0xEB5D, LocationType.Regular, "Sewers - Secret Room - Left",
                     items => items.CanLiftLight() || items.Lamp && items.KeyHC),
                 new Location(this, 256+93, 0xEB60, LocationType.Regular, "Sewers - Secret Room - Middle",
@@ -21,15 +22,15 @@ namespace Randomizer.SMZ3.Regions.Zelda {
                     items => items.CanLiftLight() || items.Lamp && items.KeyHC),
                 new Location(this, 256+95, 0xE96E, LocationType.Regular, "Sewers - Dark Cross",
                     items => items.Lamp),
-                new Location(this, 256+96, 0xEB0C, LocationType.Regular, "Hyrule Castle - Map Chest"),
+                new Location(this, 256+96, 0xEB0C, LocationType.Regular, "Hyrule Castle - Map Chest").Weighted(sphereOne),
                 new Location(this, 256+97, 0xE974, LocationType.Regular, "Hyrule Castle - Boomerang Chest",
                     items => items.KeyHC),
                 new Location(this, 256+98, 0xEB09, LocationType.Regular, "Hyrule Castle - Zelda's Cell",
                     items => items.KeyHC),
                 new Location(this, 256+99, 0x2DF45, LocationType.Regular, "Link's Uncle")
-                    .Allow((item, items) => Config.Keysanity || !item.IsDungeonItem),
+                    .Allow((item, items) => Config.Keysanity || !item.IsDungeonItem).Weighted(sphereOne),
                 new Location(this, 256+100, 0xE971, LocationType.Regular, "Secret Passage")
-                    .Allow((item, items) => Config.Keysanity || !item.IsDungeonItem),
+                    .Allow((item, items) => Config.Keysanity || !item.IsDungeonItem).Weighted(sphereOne),
             };
         }
 

--- a/Randomizer.SMZ3/Regions/Zelda/HyruleCastle.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/HyruleCastle.cs
@@ -24,9 +24,9 @@ namespace Randomizer.SMZ3.Regions.Zelda {
                     items => items.Lamp),
                 new Location(this, 256+96, 0xEB0C, LocationType.Regular, "Hyrule Castle - Map Chest").Weighted(sphereOne),
                 new Location(this, 256+97, 0xE974, LocationType.Regular, "Hyrule Castle - Boomerang Chest",
-                    items => items.KeyHC),
+                    items => items.KeyHC).Weighted(sphereOne),
                 new Location(this, 256+98, 0xEB09, LocationType.Regular, "Hyrule Castle - Zelda's Cell",
-                    items => items.KeyHC),
+                    items => items.KeyHC).Weighted(sphereOne),
                 new Location(this, 256+99, 0x2DF45, LocationType.NotInDungeon, "Link's Uncle")
                     .Allow((item, items) => Config.Keysanity || !item.IsDungeonItem).Weighted(sphereOne),
                 new Location(this, 256+100, 0xE971, LocationType.NotInDungeon, "Secret Passage")

--- a/Randomizer.SMZ3/Regions/Zelda/LightWorld/NorthEast.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/LightWorld/NorthEast.cs
@@ -9,6 +9,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld {
         public override string Area => "Light World";
 
         public NorthEast(World world, Config config) : base(world, config) {
+            var sphereOne = -10;
             Locations = new List<Location> {
                 new Location(this, 256+36, 0xEE1C3, LocationType.Regular, "King Zora",
                     items => items.CanLiftLight() || items.Flippers),
@@ -20,11 +21,11 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld {
                     items => items.Flippers),
                 new Location(this, 256+40, 0x180014, LocationType.Regular, "Potion Shop",
                     items => items.Mushroom),
-                new Location(this, 256+41, 0xEA82, LocationType.Regular, "Sahasrahla's Hut - Left"),
-                new Location(this, 256+42, 0xEA85, LocationType.Regular, "Sahasrahla's Hut - Middle"),
-                new Location(this, 256+43, 0xEA88, LocationType.Regular, "Sahasrahla's Hut - Right"),
+                new Location(this, 256+41, 0xEA82, LocationType.Regular, "Sahasrahla's Hut - Left").Weighted(sphereOne),
+                new Location(this, 256+42, 0xEA85, LocationType.Regular, "Sahasrahla's Hut - Middle").Weighted(sphereOne),
+                new Location(this, 256+43, 0xEA88, LocationType.Regular, "Sahasrahla's Hut - Right").Weighted(sphereOne),
                 new Location(this, 256+44, 0x2F1FC, LocationType.Regular, "Sahasrahla",
-                    items => World.CanAquire(items, PendantGreen))
+                    items => World.CanAquire(items, PendantGreen)),
             };
         }
 

--- a/Randomizer.SMZ3/Regions/Zelda/LightWorld/NorthWest.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/LightWorld/NorthWest.cs
@@ -9,11 +9,12 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld {
         public override string Area => "Light World";
 
         public NorthWest(World world, Config config) : base(world, config) {
+            var sphereOne = -14;
             Locations = new List<Location> {
                 new Location(this, 256+14, 0x289B0, LocationType.Pedestal, "Master Sword Pedestal",
                     items => World.CanAquireAll(items, PendantGreen, PendantNonGreen)),
-                new Location(this, 256+15, 0x180013, LocationType.Regular, "Mushroom"),
-                new Location(this, 256+16, 0x180000, LocationType.Regular, "Lost Woods Hideout"),
+                new Location(this, 256+15, 0x180013, LocationType.Regular, "Mushroom").Weighted(sphereOne),
+                new Location(this, 256+16, 0x180000, LocationType.Regular, "Lost Woods Hideout").Weighted(sphereOne),
                 new Location(this, 256+17, 0x180001, LocationType.Regular, "Lumberjack Tree",
                     items => World.CanAquire(items, Agahnim) && items.Boots),
                 new Location(this, 256+18, 0xEB3F, LocationType.Regular, "Pegasus Rocks",
@@ -24,21 +25,21 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld {
                     items => items.Boots && (
                         items.CanLiftHeavy() ||
                         items.Mirror && items.MoonPearl && World.CanEnter("Dark World North West", items))),
-                new Location(this, 256+21, 0xEA8E, LocationType.Regular, "Kakariko Well - Top"),
-                new Location(this, 256+22, 0xEA91, LocationType.Regular, "Kakariko Well - Left"),
-                new Location(this, 256+23, 0xEA94, LocationType.Regular, "Kakariko Well - Middle"),
-                new Location(this, 256+24, 0xEA97, LocationType.Regular, "Kakariko Well - Right"),
-                new Location(this, 256+25, 0xEA9A, LocationType.Regular, "Kakariko Well - Bottom"),
-                new Location(this, 256+26, 0xEB0F, LocationType.Regular, "Blind's Hideout - Top"),
-                new Location(this, 256+27, 0xEB18, LocationType.Regular, "Blind's Hideout - Far Left"),
-                new Location(this, 256+28, 0xEB12, LocationType.Regular, "Blind's Hideout - Left"),
-                new Location(this, 256+29, 0xEB15, LocationType.Regular, "Blind's Hideout - Right"),
-                new Location(this, 256+30, 0xEB1B, LocationType.Regular, "Blind's Hideout - Far Right"),
-                new Location(this, 256+31, 0x2EB18, LocationType.Regular, "Bottle Merchant"),
-                new Location(this, 256+250, 0xE9E9, LocationType.Regular, "Chicken House"),
+                new Location(this, 256+21, 0xEA8E, LocationType.Regular, "Kakariko Well - Top").Weighted(sphereOne),
+                new Location(this, 256+22, 0xEA91, LocationType.Regular, "Kakariko Well - Left").Weighted(sphereOne),
+                new Location(this, 256+23, 0xEA94, LocationType.Regular, "Kakariko Well - Middle").Weighted(sphereOne),
+                new Location(this, 256+24, 0xEA97, LocationType.Regular, "Kakariko Well - Right").Weighted(sphereOne),
+                new Location(this, 256+25, 0xEA9A, LocationType.Regular, "Kakariko Well - Bottom").Weighted(sphereOne),
+                new Location(this, 256+26, 0xEB0F, LocationType.Regular, "Blind's Hideout - Top").Weighted(sphereOne),
+                new Location(this, 256+27, 0xEB18, LocationType.Regular, "Blind's Hideout - Far Left").Weighted(sphereOne),
+                new Location(this, 256+28, 0xEB12, LocationType.Regular, "Blind's Hideout - Left").Weighted(sphereOne),
+                new Location(this, 256+29, 0xEB15, LocationType.Regular, "Blind's Hideout - Right").Weighted(sphereOne),
+                new Location(this, 256+30, 0xEB1B, LocationType.Regular, "Blind's Hideout - Far Right").Weighted(sphereOne),
+                new Location(this, 256+31, 0x2EB18, LocationType.Regular, "Bottle Merchant").Weighted(sphereOne),
+                new Location(this, 256+250, 0xE9E9, LocationType.Regular, "Chicken House").Weighted(sphereOne),
                 new Location(this, 256+33, 0x339CF, LocationType.Regular, "Sick Kid",
                     items => items.Bottle),
-                new Location(this, 256+34, 0xE9CE, LocationType.Regular, "Kakariko Tavern"),
+                new Location(this, 256+34, 0xE9CE, LocationType.Regular, "Kakariko Tavern").Weighted(sphereOne),
                 new Location(this, 256+35, 0x180015, LocationType.Regular, "Magic Bat",
                     items => items.Powder && (items.Hammer || items.MoonPearl && items.Mirror && items.CanLiftHeavy())),
             };

--- a/Randomizer.SMZ3/Regions/Zelda/LightWorld/South.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/LightWorld/South.cs
@@ -8,21 +8,22 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld {
         public override string Area => "Light World";
 
         public South(World world, Config config) : base(world, config) {
+            var sphereOne = -10;
             Locations = new List<Location> {
-                new Location(this, 256+45, 0x180142, LocationType.Regular, "Maze Race"),
+                new Location(this, 256+45, 0x180142, LocationType.Regular, "Maze Race").Weighted(sphereOne),
                 new Location(this, 256+240, 0x180012, LocationType.Regular, "Library",
                     items => items.Boots),
                 new Location(this, 256+241, 0x18014A, LocationType.Regular, "Flute Spot",
                     items => items.Shovel),
                 new Location(this, 256+242, 0x180003, LocationType.Regular, "South of Grove",
                     items => items.Mirror && World.CanEnter("Dark World South", items)),
-                new Location(this, 256+243, 0xE9BC, LocationType.Regular, "Link's House"),
-                new Location(this, 256+244, 0xE9F2, LocationType.Regular, "Aginah's Cave"),
-                new Location(this, 256+51, 0xEB42, LocationType.Regular, "Mini Moldorm Cave - Far Left"),
-                new Location(this, 256+52, 0xEB45, LocationType.Regular, "Mini Moldorm Cave - Left"),
-                new Location(this, 256+53, 0x180010, LocationType.Regular, "Mini Moldorm Cave - NPC"),
-                new Location(this, 256+54, 0xEB48, LocationType.Regular, "Mini Moldorm Cave - Right"),
-                new Location(this, 256+251, 0xEB4B, LocationType.Regular, "Mini Moldorm Cave - Far Right"),
+                new Location(this, 256+243, 0xE9BC, LocationType.Regular, "Link's House").Weighted(sphereOne),
+                new Location(this, 256+244, 0xE9F2, LocationType.Regular, "Aginah's Cave").Weighted(sphereOne),
+                new Location(this, 256+51, 0xEB42, LocationType.Regular, "Mini Moldorm Cave - Far Left").Weighted(sphereOne),
+                new Location(this, 256+52, 0xEB45, LocationType.Regular, "Mini Moldorm Cave - Left").Weighted(sphereOne),
+                new Location(this, 256+53, 0x180010, LocationType.Regular, "Mini Moldorm Cave - NPC").Weighted(sphereOne),
+                new Location(this, 256+54, 0xEB48, LocationType.Regular, "Mini Moldorm Cave - Right").Weighted(sphereOne),
+                new Location(this, 256+251, 0xEB4B, LocationType.Regular, "Mini Moldorm Cave - Far Right").Weighted(sphereOne),
                 new Location(this, 256+252, 0x180143, LocationType.Regular, "Desert Ledge",
                     items => World.CanEnter("Desert Palace", items)),
                 new Location(this, 256+253, 0x180005, LocationType.Regular, "Checkerboard Cave",
@@ -32,15 +33,15 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld {
                     ) && items.CanLiftLight()),
                 new Location(this, 256+58, 0x180017, LocationType.Bombos, "Bombos Tablet",
                     items => items.Book && items.MasterSword && items.Mirror && World.CanEnter("Dark World South", items)),
-                new Location(this, 256+59, 0xE98C, LocationType.Regular, "Floodgate Chest"),
-                new Location(this, 256+60, 0x180145, LocationType.Regular, "Sunken Treasure"),
+                new Location(this, 256+59, 0xE98C, LocationType.Regular, "Floodgate Chest").Weighted(sphereOne),
+                new Location(this, 256+60, 0x180145, LocationType.Regular, "Sunken Treasure").Weighted(sphereOne),
                 new Location(this, 256+61, 0x180144, LocationType.Regular, "Lake Hylia Island",
                     items => items.Flippers && items.MoonPearl && items.Mirror && (
                         World.CanEnter("Dark World South", items) ||
                         World.CanEnter("Dark World North East", items))),
                 new Location(this, 256+62, 0x33E7D, LocationType.Regular, "Hobo",
                     items => items.Flippers),
-                new Location(this, 256+63, 0xEB4E, LocationType.Regular, "Ice Rod Cave"),
+                new Location(this, 256+63, 0xEB4E, LocationType.Regular, "Ice Rod Cave").Weighted(sphereOne),
             };
 
         }

--- a/Randomizer.SMZ3/World.cs
+++ b/Randomizer.SMZ3/World.cs
@@ -9,11 +9,14 @@ namespace Randomizer.SMZ3 {
 
         public List<Location> Locations { get; set; }
         public List<Region> Regions { get; set; }
-        public List<Item> Items { get; set; }
         public Config Config { get; set; }
         public string Player { get; set; }
         public string Guid { get; set; }
         public int Id { get; set; }
+
+        public IEnumerable<Item> Items {
+            get { return Locations.Select(l => l.Item).Where(i => i != null); }
+        }
 
         public World(Config config, string player, int id, string guid) {
             Config = config;
@@ -65,7 +68,6 @@ namespace Randomizer.SMZ3 {
             };
 
             Locations = Regions.SelectMany(x => x.Locations).ToList();
-            Items = new List<Item>();
         }
 
         public bool CanEnter(string regionName, Progression items) {


### PR DESCRIPTION
This PR evolves the `Filler` to do location weighting for a single player seed, and handles difference under keysanity.

Additional behavioral changes:
- Reorder morphs before moonpearls. Better to possibly move moonpearls up from their last quarter than morphs up from their last half of the list.
- Non-dungeon item pools are shuffled as a common pools from all worlds.
- Locations are shuffled once before dungeon assumed fill, and once (plus weight) for the rest of the items.
- Weight values are simplified numbers taken from the v10.2 PHP implementation:
    - Brinstar Green: -6
    - Brinstar Pink: -4
    - Light World, only affecting sphere 1 location:
        - North West: -14
        - North East, South, Hyrule Castle: -10

What constitutes a "sphere 1 location" in Hyrule Castle needs additional consideration. The two inner chests in the front are technically not sphere 1 since there is a KeyHC requirement to avoid worst key use. But should they be considered sphere 1 anyway from a rando design perspective?