### PR TITLE
Set rom game title and seed configuration

### DIFF
--- a/Randomizer.SMZ3/Config.cs
+++ b/Randomizer.SMZ3/Config.cs
@@ -2,9 +2,8 @@
 
     enum SMLogic {
         Casual,
-        Tournament,
-        Normal,
-        Hard,
+        Basic,
+        Advanced,
     }
 
     enum Difficulty {
@@ -24,7 +23,7 @@
 
     class Config {
 
-        public SMLogic SMLogic { get; set; } = SMLogic.Tournament;
+        public SMLogic SMLogic { get; set; } = SMLogic.Advanced;
         public Difficulty Difficulty { get; set; } = Difficulty.Normal;
         public bool Keysanity { get; set; } = false;
         public GanonInvincible GanonInvincible { get; set; } = GanonInvincible.BeforeCrystals;

--- a/Randomizer.SMZ3/Config.cs
+++ b/Randomizer.SMZ3/Config.cs
@@ -1,5 +1,11 @@
 ﻿namespace Randomizer.SMZ3 {
 
+    enum Z3Logic {
+        Nmg,
+        Owg,
+        Mg,
+    }
+
     enum SMLogic {
         Casual,
         Basic,
@@ -23,6 +29,7 @@
 
     class Config {
 
+        public Z3Logic Z3Logic { get; set; } = Z3Logic.Nmg;
         public SMLogic SMLogic { get; set; } = SMLogic.Advanced;
         public Difficulty Difficulty { get; set; } = Difficulty.Normal;
         public bool Keysanity { get; set; } = false;

--- a/Randomizer.SMZ3/Config.cs
+++ b/Randomizer.SMZ3/Config.cs
@@ -1,6 +1,6 @@
 ﻿namespace Randomizer.SMZ3 {
 
-    enum Logic {
+    enum SMLogic {
         Casual,
         Tournament,
         Normal,
@@ -24,7 +24,7 @@
 
     class Config {
 
-        public Logic Logic { get; set; } = Logic.Tournament;
+        public SMLogic SMLogic { get; set; } = SMLogic.Tournament;
         public Difficulty Difficulty { get; set; } = Difficulty.Normal;
         public bool Keysanity { get; set; } = false;
         public GanonInvincible GanonInvincible { get; set; } = GanonInvincible.BeforeCrystals;

--- a/Randomizer.SMZ3/HexGuid.cs
+++ b/Randomizer.SMZ3/HexGuid.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Randomizer.SMZ3 {
+
+    class HexGuid {
+        public Guid Guid { get; } = Guid.NewGuid();
+        public override string ToString() => Guid.ToString().Replace("-", "");
+        public static implicit operator string(HexGuid hexGuid) => hexGuid.ToString();
+    }
+
+}

--- a/Randomizer.SMZ3/Item.cs
+++ b/Randomizer.SMZ3/Item.cs
@@ -387,6 +387,17 @@ namespace Randomizer.SMZ3 {
         public bool KeyTH { get; private set; }
         public bool KeySP { get; private set; }
         public bool KeyTT { get; private set; }
+        public int KeyCT { get; private set; }
+        public int KeyPD { get; private set; }
+        public int KeySW { get; private set; }
+        public int KeyIP { get; private set; }
+        public int KeyMM { get; private set; }
+        public int KeyTR { get; private set; }
+        public int KeyGT { get; private set; }
+        public bool KraidKey { get; private set; }
+        public bool PhantoonKey { get; private set; }
+        public bool DraygonKey { get; private set; }
+        public bool RidleyKey { get; private set; }
         public bool CanBlockLasers { get { return shield >= 3; } }
         public bool Sword { get; private set; }
         public bool MasterSword { get; private set; }
@@ -436,11 +447,7 @@ namespace Randomizer.SMZ3 {
         public int ETank { get; private set; }
         public int ReserveTank { get; private set; }
 
-        public bool Has(ItemType itemType) => remaining.Any(x => x == itemType);
-        public bool Has(ItemType itemType, int amount) => remaining.Count(x => x == itemType) >= amount;
-
         int shield;
-        readonly List<ItemType> remaining = new List<ItemType>();
 
         public Progression(IEnumerable<Item> items) {
             Add(items);
@@ -465,6 +472,10 @@ namespace Randomizer.SMZ3 {
                     ItemType.KeyTH => KeyTH = true,
                     ItemType.KeySP => KeySP = true,
                     ItemType.KeyTT => KeyTT = true,
+                    ItemType.KraidKey => KraidKey = true,
+                    ItemType.PhantoonKey => PhantoonKey = true,
+                    ItemType.DraygonKey => DraygonKey = true,
+                    ItemType.RidleyKey => RidleyKey = true,
                     ItemType.Bow => Bow = true,
                     ItemType.Hookshot => Hookshot = true,
                     ItemType.Mushroom => Mushroom = true,
@@ -511,15 +522,16 @@ namespace Randomizer.SMZ3 {
                     continue;
 
                 switch (item.Type) {
-                    case ProgressiveShield:
-                        shield += 1;
-                        break;
-                    case ItemType.ETank:
-                        ETank += 1;
-                        break;
-                    case ItemType.ReserveTank:
-                        ReserveTank += 1;
-                        break;
+                    case ItemType.KeyCT: KeyCT += 1; break;
+                    case ItemType.KeyPD: KeyPD += 1; break;
+                    case ItemType.KeySW: KeySW += 1; break;
+                    case ItemType.KeyIP: KeyIP += 1; break;
+                    case ItemType.KeyMM: KeyMM += 1; break;
+                    case ItemType.KeyTR: KeyTR += 1; break;
+                    case ItemType.KeyGT: KeyGT += 1; break;
+                    case ItemType.ETank: ETank += 1; break;
+                    case ItemType.ReserveTank: ReserveTank += 1; break;
+                    case ProgressiveShield: shield += 1; break;
                     case ProgressiveSword:
                         MasterSword = Sword;
                         Sword = true;
@@ -531,9 +543,6 @@ namespace Randomizer.SMZ3 {
                     case ItemType.PowerBomb:
                         TwoPowerBombs = PowerBomb;
                         PowerBomb = true;
-                        break;
-                    default:
-                        remaining.Add(item.Type);
                         break;
                 }
             }

--- a/Randomizer.SMZ3/Item.cs
+++ b/Randomizer.SMZ3/Item.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Collections.Generic;
 using static Randomizer.SMZ3.ItemType;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 using static Randomizer.SMZ3.RewardType;
 using System.Text.RegularExpressions;
 
@@ -577,7 +577,7 @@ namespace Randomizer.SMZ3 {
         }
 
         public static bool CanAccessDarkWorldPortal(this Progression items, Config config) {
-            return config.Logic switch {
+            return config.SMLogic switch {
                 Casual =>
                     items.CanUsePowerBombs() && items.Super && items.Gravity && items.SpeedBooster,
                 _ =>
@@ -589,7 +589,7 @@ namespace Randomizer.SMZ3 {
         }
 
         public static bool CanAccessMiseryMirePortal(this Progression items, Config config) {
-            return config.Logic switch {
+            return config.SMLogic switch {
                 Casual =>
                     items.Varia && items.Super && (items.Gravity && items.SpaceJump) && items.CanUsePowerBombs(),
                 _ =>
@@ -642,7 +642,7 @@ namespace Randomizer.SMZ3 {
         }
 
         public static bool CanAccessMaridiaPortal(this Progression items, World world) {
-            return world.Config.Logic switch {
+            return world.Config.SMLogic switch {
                 Casual =>
                     items.MoonPearl && items.Flippers &&
                     items.Gravity && items.Morph &&

--- a/Randomizer.SMZ3/Patch.cs
+++ b/Randomizer.SMZ3/Patch.cs
@@ -468,9 +468,17 @@ namespace Randomizer.SMZ3 {
         }
 
         void WriteSeedData() {
+            var configField =
+                ((int)myWorld.Config.Z3Logic << 10) |
+                ((int)myWorld.Config.SMLogic << 8) |
+                (Randomizer.version.Major << 4) |
+                (Randomizer.version.Minor << 0);
+
             patches.Add((SMSnes(0xC07F50), UshortBytes(myWorld.Id)));
-            /* Seed configuration bitfield */
-            patches.Add((SMSnes(0xC07F52), UintBytes(0)));
+            patches.Add((SMSnes(0xC07F52), UshortBytes(configField)));
+            patches.Add((SMSnes(0xC07F54), UintBytes(seed)));
+            /* Reserve the rest of the space for future use */
+            patches.Add((SMSnes(0xC07F58), Repeat<byte>(0x00, 8).ToArray()));
             patches.Add((SMSnes(0xC07F60), AsAscii(seedGuid)));
             patches.Add((SMSnes(0xC07F80), AsAscii(myWorld.Guid)));
         }

--- a/Randomizer.SMZ3/Patch.cs
+++ b/Randomizer.SMZ3/Patch.cs
@@ -468,7 +468,7 @@ namespace Randomizer.SMZ3 {
         }
 
         void WriteSeedData() {
-            patches.Add((SMSnes(0xC07F50), UintBytes(myWorld.Id)));
+            patches.Add((SMSnes(0xC07F50), UshortBytes(myWorld.Id)));
             /* Seed configuration bitfield */
             patches.Add((SMSnes(0xC07F52), UintBytes(0)));
             patches.Add((SMSnes(0xC07F60), AsciiBytes(seedGuid)));

--- a/Randomizer.SMZ3/Patch.cs
+++ b/Randomizer.SMZ3/Patch.cs
@@ -80,8 +80,6 @@ namespace Randomizer.SMZ3 {
             WriteSaveAndQuitFromBossRoom();
             WriteWorldOnAgahnimDeath();
 
-            patches = RemapComboOffsets(patches);
-
             WriteSMLocations(myWorld.Regions.OfType<SMRegion>().SelectMany(x => x.Locations));
             WriteZ3Locations(myWorld.Regions.OfType<Z3Region>().SelectMany(x => x.Locations));
 
@@ -114,8 +112,8 @@ namespace Randomizer.SMZ3 {
                 var x => throw new InvalidOperationException($"Tried using {x} in place of Misery Mire medallion")
             };
 
-            patches.AddRange(turtleRockAddresses.Zip(turtleRockValues, (i, b) => (i, new byte[] { b })));
-            patches.AddRange(miseryMireAddresses.Zip(miseryMireValues, (i, b) => (i, new byte[] { b })));
+            patches.AddRange(turtleRockAddresses.Zip(turtleRockValues, (i, b) => (Z3Snes(i), new byte[] { b })));
+            patches.AddRange(miseryMireAddresses.Zip(miseryMireValues, (i, b) => (Z3Snes(i), new byte[] { b })));
         }
 
         void WriteRewards() {
@@ -139,7 +137,7 @@ namespace Randomizer.SMZ3 {
             var addresses = regions.Select(RewardAddresses);
             var values = rewards.Select(rewardValues);
             var associations = addresses.Zip(values, (a, v) => (a, v));
-            return associations.SelectMany(x => x.a.Zip(x.v, (i, b) => (i, new byte[] { b })));
+            return associations.SelectMany(x => x.a.Zip(x.v, (i, b) => (Z3Snes(i), new byte[] { b })));
         }
 
         int[] RewardAddresses(IReward region) {
@@ -189,7 +187,7 @@ namespace Randomizer.SMZ3 {
                     var x => throw new InvalidOperationException($"Location {location.Name} should not have the type {x}")
                 };
 
-                patches.Add((0x80000 + location.Address, locationValue));
+                patches.Add((SMSnes(location.Address), locationValue));
                 patches.Add(ItemTablePatch(location, (byte)location.Item.Type));
             }
         }
@@ -197,24 +195,24 @@ namespace Randomizer.SMZ3 {
         void WriteZ3Locations(IEnumerable<Location> locations) {
             foreach (var location in locations) {
                 if (location.Type == LocationType.HeraStandingKey) {
-                    patches.Add((ComboOffset(0x4E3BB), location.Item.Type == KeyTH ? new byte[] { 0xE4 } : new byte[] { 0xEB }));
+                    patches.Add((Z3Snes(0x4E3BB), location.Item.Type == KeyTH ? new byte[] { 0xE4 } : new byte[] { 0xEB }));
                 } else if (new[] { LocationType.Pedestal, LocationType.Ether, LocationType.Bombos }.Contains(location.Type)) {
                     var text = Texts.ItemTextbox(location.Item);
                     var dialog = Dialog.Simple(text);
                     if (location.Type == LocationType.Pedestal) {
                         stringTable.SetPedestalText(text);
-                        patches.Add((ComboOffset(0x180300), dialog));
+                        patches.Add((Z3Snes(0x180300), dialog));
                     }
                     else if (location.Type == LocationType.Ether) {
                         stringTable.SetEtherText(text);
-                        patches.Add((ComboOffset(0x180F00), dialog));
+                        patches.Add((Z3Snes(0x180F00), dialog));
                     }
                     else if (location.Type == LocationType.Bombos) {
                         stringTable.SetBombosText(text);
-                        patches.Add((ComboOffset(0x181000), dialog));
+                        patches.Add((Z3Snes(0x181000), dialog));
                     }
                 }
-                patches.Add((ComboOffset(location.Address), new byte[] { (byte)(location.Id - 256) }));
+                patches.Add((Z3Snes(location.Address), new byte[] { (byte)(location.Id - 256) }));
                 patches.Add(ItemTablePatch(location, GetZ3ItemId(location.Item.Type)));
             }
         }
@@ -262,7 +260,7 @@ namespace Randomizer.SMZ3 {
         IEnumerable<(int, byte[])> MusicPatches(IEnumerable<IReward> regions, IEnumerable<byte> music) {
             var addresses = regions.Select(MusicAddresses);
             var associations = addresses.Zip(music, (a, b) => (a, b));
-            return associations.SelectMany(x => x.a.Select(i => (i, new byte[] { x.b })));
+            return associations.SelectMany(x => x.a.Select(i => (Z3Snes(i), new byte[] { x.b })));
         }
 
         int[] MusicAddresses(IReward region) {
@@ -313,24 +311,24 @@ namespace Randomizer.SMZ3 {
 
             /* prize pack drop order */
             (bytes, prizes) = prizes.SplitOff(prizePackItems);
-            patches.Add((0x37A78, bytes.ToArray()));
+            patches.Add((Z3Snes(0x37A78), bytes.ToArray()));
 
             /* tree pull prizes */
             (bytes, prizes) = prizes.SplitOff(treePullItems);
-            patches.Add((0xEFBD4, bytes.ToArray()));
+            patches.Add((Z3Snes(0xEFBD4), bytes.ToArray()));
 
             /* crab prizes */
             (drop, final, prizes) = prizes;
-            patches.Add((0x329C8, new[] { drop }));
-            patches.Add((0x329C4, new[] { final }));
+            patches.Add((Z3Snes(0x329C8), new[] { drop }));
+            patches.Add((Z3Snes(0x329C4), new[] { final }));
 
             /* stun prize */
             (drop, prizes) = prizes;
-            patches.Add((0x37993, new[] { drop }));
+            patches.Add((Z3Snes(0x37993), new[] { drop }));
 
             /* fish prize */
             (drop, _) = prizes;
-            patches.Add((0xE82CC, new[] { drop }));
+            patches.Add((Z3Snes(0xE82CC), new[] { drop }));
 
             patches.AddRange(EnemyPrizePackDistribution());
 
@@ -343,10 +341,10 @@ namespace Randomizer.SMZ3 {
                 Difficulty.Hard => (byte)1,
                 _ => (byte)3,
             };
-            patches.Add((0x37A62, Repeat(p, nrPacks).ToArray()));
+            patches.Add((Z3Snes(0x37A62), Repeat(p, nrPacks).ToArray()));
         }
 
-        IEnumerable<(int offset, byte[] bytes)> EnemyPrizePackDistribution() {
+        IEnumerable<(int, byte[])> EnemyPrizePackDistribution() {
             var (prizePacks, duplicatePacks) = EnemyPrizePacks();
 
             var n = prizePacks.Sum(x => x.bytes.Length);
@@ -365,7 +363,7 @@ namespace Randomizer.SMZ3 {
                 select (d.dest, p.bytes);
             patches.AddRange(duplicates.ToList());
 
-            return patches;
+            return patches.Select(x => (Z3Snes(x.offset), x.bytes));
         }
 
         /* Guarantees at least s of each prize pack, over a total of n packs.
@@ -451,7 +449,7 @@ namespace Randomizer.SMZ3 {
         }
 
         void WriteStringTable() {
-            patches.Add((ComboOffset(0xE0000), stringTable.GetPaddedBytes()));
+            patches.Add((Z3Snes(0xE0000), stringTable.GetPaddedBytes()));
         }
 
         void WritePlayerNames() {
@@ -470,38 +468,38 @@ namespace Randomizer.SMZ3 {
         }
 
         void WriteSeedData() {
-            patches.Add((0x00FF50, UintBytes(myWorld.Id)));
+            patches.Add((SMSnes(0xC07F50), UintBytes(myWorld.Id)));
             /* Seed configuration bitfield */
-            patches.Add((0x00FF52, UintBytes(0)));
-            patches.Add((0x00FF60, AsciiBytes(seedGuid)));
-            patches.Add((0x00FF80, AsciiBytes(myWorldGuid)));
+            patches.Add((SMSnes(0xC07F52), UintBytes(0)));
+            patches.Add((SMSnes(0xC07F60), AsciiBytes(seedGuid)));
+            patches.Add((SMSnes(0xC07F80), AsciiBytes(myWorldGuid)));
         }
 
         void WriteWishingWellRoomData() {
-            patches.Add((0x1F714, wishingWellRoomData));
+            patches.Add((Z3Snes(0x1F714), wishingWellRoomData));
         }
 
         void WriteWishingWellChests() {
-            patches.Add((0xE9AE, new byte[] { 0x14, 0x01 }));
-            patches.Add((0xE9CF, new byte[] { 0x14, 0x01 }));
+            patches.Add((Z3Snes(0xE9AE), new byte[] { 0x14, 0x01 }));
+            patches.Add((Z3Snes(0xE9CF), new byte[] { 0x14, 0x01 }));
         }
 
         void WritePyramidFairyChests() {
-            patches.Add((0x1FC16, new byte[] { 0xB1, 0xC6, 0xF9, 0xC9, 0xC6, 0xF9 }));
+            patches.Add((Z3Snes(0x1FC16), new byte[] { 0xB1, 0xC6, 0xF9, 0xC9, 0xC6, 0xF9 }));
         }
 
         void WriteDiggingGameRng() {
             byte digs = (byte)(rnd.Next(30) + 1);
-            patches.Add((0x180020, new byte[] { digs }));
-            patches.Add((0xEFD95, new byte[] { digs }));
+            patches.Add((Z3Snes(0x180020), new byte[] { digs }));
+            patches.Add((Z3Snes(0xEFD95), new byte[] { digs }));
         }
 
         void WriteOpenModeFlags() {
             patches.AddRange(new[] {
-                (0x180032, new byte[] { 0x01 }),
-                (0x180038, new byte[] { 0x00 }),
-                (0x180039, new byte[] { 0x00 }),
-                (0x18003A, new byte[] { 0x00 }),
+                (Z3Snes(0x180032), new byte[] { 0x01 }),
+                (Z3Snes(0x180038), new byte[] { 0x00 }),
+                (Z3Snes(0x180039), new byte[] { 0x00 }),
+                (Z3Snes(0x18003A), new byte[] { 0x00 }),
             });
         }
 
@@ -510,42 +508,42 @@ namespace Randomizer.SMZ3 {
         void WriteRemoveEquipmentFromUncle(Item item) {
             if (item.Type != ProgressiveSword) {
                 patches.AddRange(new[] {
-                    (0x6D263, new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x0E }),
-                    (0x6D26B, new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x0E }),
-                    (0x6D293, new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x0E }),
-                    (0x6D29B, new byte[] { 0x00, 0x00, 0xF7, 0xFF, 0x00, 0x0E }),
-                    (0x6D2B3, new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x02, 0x0E }),
-                    (0x6D2BB, new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x02, 0x0E }),
-                    (0x6D2E3, new byte[] { 0x00, 0x00, 0xF7, 0xFF, 0x02, 0x0E }),
-                    (0x6D2EB, new byte[] { 0x00, 0x00, 0xF7, 0xFF, 0x02, 0x0E }),
-                    (0x6D31B, new byte[] { 0x00, 0x00, 0xE4, 0xFF, 0x08, 0x0E }),
-                    (0x6D323, new byte[] { 0x00, 0x00, 0xE4, 0xFF, 0x08, 0x0E }),
+                    (Z3Snes(0x6D263), new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x0E }),
+                    (Z3Snes(0x6D26B), new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x0E }),
+                    (Z3Snes(0x6D293), new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x0E }),
+                    (Z3Snes(0x6D29B), new byte[] { 0x00, 0x00, 0xF7, 0xFF, 0x00, 0x0E }),
+                    (Z3Snes(0x6D2B3), new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x02, 0x0E }),
+                    (Z3Snes(0x6D2BB), new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x02, 0x0E }),
+                    (Z3Snes(0x6D2E3), new byte[] { 0x00, 0x00, 0xF7, 0xFF, 0x02, 0x0E }),
+                    (Z3Snes(0x6D2EB), new byte[] { 0x00, 0x00, 0xF7, 0xFF, 0x02, 0x0E }),
+                    (Z3Snes(0x6D31B), new byte[] { 0x00, 0x00, 0xE4, 0xFF, 0x08, 0x0E }),
+                    (Z3Snes(0x6D323), new byte[] { 0x00, 0x00, 0xE4, 0xFF, 0x08, 0x0E }),
                 });
             }
             if (item.Type != ProgressiveShield) {
                 patches.AddRange(new[] {
-                    (0x6D253, new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x0E }),
-                    (0x6D25B, new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x0E }),
-                    (0x6D283, new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x0E }),
-                    (0x6D28B, new byte[] { 0x00, 0x00, 0xF7, 0xFF, 0x00, 0x0E }),
-                    (0x6D2CB, new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x02, 0x0E }),
-                    (0x6D2FB, new byte[] { 0x00, 0x00, 0xF7, 0xFF, 0x02, 0x0E }),
-                    (0x6D313, new byte[] { 0x00, 0x00, 0xE4, 0xFF, 0x08, 0x0E }),
+                    (Z3Snes(0x6D253), new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x0E }),
+                    (Z3Snes(0x6D25B), new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x0E }),
+                    (Z3Snes(0x6D283), new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x0E }),
+                    (Z3Snes(0x6D28B), new byte[] { 0x00, 0x00, 0xF7, 0xFF, 0x00, 0x0E }),
+                    (Z3Snes(0x6D2CB), new byte[] { 0x00, 0x00, 0xF6, 0xFF, 0x02, 0x0E }),
+                    (Z3Snes(0x6D2FB), new byte[] { 0x00, 0x00, 0xF7, 0xFF, 0x02, 0x0E }),
+                    (Z3Snes(0x6D313), new byte[] { 0x00, 0x00, 0xE4, 0xFF, 0x08, 0x0E }),
                 });
             }
         }
 
         void WriteLockAgahnimDoorInEscape() {
-            patches.Add((0x180169, new byte[] { 0x01 }));
+            patches.Add((Z3Snes(0x180169), new byte[] { 0x01 }));
         }
 
         void WriteWishingWellUpgradeFalse() {
-            patches.Add((0x348DB, new byte[] { 0x2A }));
-            patches.Add((0x348EB, new byte[] { 0x05 }));
+            patches.Add((Z3Snes(0x348DB), new byte[] { 0x2A }));
+            patches.Add((Z3Snes(0x348EB), new byte[] { 0x05 }));
         }
 
         void WriteRestrictFairyPonds() {
-            patches.Add((0x18017E, new byte[] { 0x01 }));
+            patches.Add((Z3Snes(0x18017E), new byte[] { 0x01 }));
         }
 
         void WriteGanonInvicible(GanonInvincible invincible) {
@@ -556,59 +554,60 @@ namespace Randomizer.SMZ3 {
                 GanonInvincible.BeforeCrystals => 0x03,
                 var x => throw new ArgumentException($"Unknown Ganon invincible value {x}", nameof(invincible))
             };
-            patches.Add((0x18003E, new byte[] { (byte)value }));
+            patches.Add((Z3Snes(0x18003E), new byte[] { (byte)value }));
         }
 
         void WriteRngBlock() {
-            patches.Add((0x178000, Range(0, 1024).Select(x => (byte)rnd.Next(0x100)).ToArray()));
+            patches.Add((Z3Snes(0x178000), Range(0, 1024).Select(x => (byte)rnd.Next(0x100)).ToArray()));
         }
 
         void WriteSmithyQuickItemGive() {
-            patches.Add((0x180029, new byte[] { 0x01 }));
+            patches.Add((Z3Snes(0x180029), new byte[] { 0x01 }));
         }
 
         void WriteSaveAndQuitFromBossRoom() {
-            patches.Add((0x180042, new byte[] { 0x01 }));
+            patches.Add((Z3Snes(0x180042), new byte[] { 0x01 }));
         }
 
         void WriteWorldOnAgahnimDeath() {
-            patches.Add((0x1800A3, new byte[] { 0x01 }));
+            patches.Add((Z3Snes(0x1800A3), new byte[] { 0x01 }));
         }
 
-        List<(int, byte[])> RemapComboOffsets(List<(int, byte[])> patches) {
-            return patches.Select(x => (ComboOffset(x.Item1), x.Item2)).ToList();
-        }
-
-        int ComboOffset(int offset) {
-            offset = offset switch {
-                /* Convert LoROM to HiROM mapping and then apply the ExHiROM offset */
-                _ when offset < 0x170000 =>
-                    0x400000 + offset + (0x8000 * ((int)Math.Floor((decimal)offset / 0x8000) + 1)),
-                /* Change 0x180000 access into ExHiROM bank 40 */
-                _ when (offset & 0xff0000) == 0x180000 =>
-                    0x400000 + (offset & 0x00ffff),
+        int Z3Snes(int addr) {
+            addr = addr switch {
+                _ when addr < 0x170000 => LoSnesAsExHiPc(addr),
+                /* Place $180000 access into ExHiROM bank 40 */
+                _ when (addr & 0xFF0000) == 0x180000 => 0x400000 | (addr & 0xFFFF),
                 /* Repoint RNG Block */
-                _ when offset == 0x178000 => 0x420000,
-                /* SM ExHiROM Header */
-                _ when (offset & 0xff0000) == 0xff0000 => offset & 0x00ffff,
-                _ => throw new InvalidOperationException($"Unmapped combo offset source {offset}"),
+                _ when addr == 0x178000 => 0x420000,
+                _ => throw new InvalidOperationException($"Unmapped Z3 snes address source ${addr:X}"),
             };
-            if (offset > 0x600000)
-                throw new InvalidOperationException($"Unmapped combo offset target {offset}");
-            return offset;
+            if (addr > 0x600000)
+                throw new InvalidOperationException($"Unmapped pc address target ${addr:X}");
+            return addr;
         }
 
-        byte[] UintBytes(int value) {
-            return BitConverter.GetBytes((uint)value);
+        int SMSnes(int addr) {
+            addr = addr switch {
+                _ when addr >= 0x800000 => LoSnesAsExHiPc(addr),
+                _ => throw new InvalidOperationException($"Unmapped SM snes address source ${addr:X}"),
+            };
+            if (addr > 0x600000)
+                throw new InvalidOperationException($"Unmapped pc address target ${addr:X}");
+            return addr;
         }
 
-        byte[] UshortBytes(int value) {
-            return BitConverter.GetBytes((ushort)value);
+        int LoSnesAsExHiPc(int addr) {
+            var ex = (addr & 0x800000) == 0 ? 0x400000 : 0;
+            var pc = ((addr << 1) & 0x3F0000) | 0x8000 | (addr & 0x7FFF);
+            return ex | pc;
         }
 
-        byte[] AsciiBytes(string s) {
-            return Encoding.ASCII.GetBytes(s);
-        }
+        byte[] UintBytes(int value) => BitConverter.GetBytes((uint)value);
+
+        byte[] UshortBytes(int value) => BitConverter.GetBytes((ushort)value);
+
+        byte[] AsciiBytes(string s) => Encoding.ASCII.GetBytes(s);
 
     }
 

--- a/Randomizer.SMZ3/Randomizer.cs
+++ b/Randomizer.SMZ3/Randomizer.cs
@@ -13,16 +13,16 @@ namespace Randomizer.SMZ3 {
 
             var rnd = new Random(int.Parse(seed));
 
-            var logic = Logic.Tournament;
+            var logic = SMLogic.Tournament;
             if (options.ContainsKey("logic")) {
                 logic = options["logic"] switch {
-                    "casual" => Logic.Casual,
-                    "tournament" => Logic.Tournament,
-                    _ => Logic.Tournament
+                    "casual" => SMLogic.Casual,
+                    "tournament" => SMLogic.Tournament,
+                    _ => SMLogic.Tournament
                 };
             }
 
-            var config = new Config { Logic = logic };
+            var config = new Config { SMLogic = logic };
             var worlds = new List<World>();
 
             int players = options.ContainsKey("worlds") ? int.Parse(options["worlds"]) : 1;

--- a/Randomizer.SMZ3/Randomizer.cs
+++ b/Randomizer.SMZ3/Randomizer.cs
@@ -27,10 +27,8 @@ namespace Randomizer.SMZ3 {
 
             int players = options.ContainsKey("worlds") ? int.Parse(options["worlds"]) : 1;
             for (int p = 0; p < players; p++) {
-                worlds.Add(new World(config, options[$"player-{p}"], p));
+                worlds.Add(new World(config, options[$"player-{p}"], p, new HexGuid()));
             }
-
-            var guid = Guid.NewGuid().ToString();
 
             var filler = new Filler(worlds, config, rnd);
             filler.Fill();
@@ -39,7 +37,7 @@ namespace Randomizer.SMZ3 {
             var spheres = playthrough.Generate();
 
             var seedData = new SeedData {
-                Guid = guid.Replace("-", ""),
+                Guid = new HexGuid(),
                 Seed = seed,
                 Game = "SMAlttP Combo Randomizer",
                 Logic = logic.ToString(),
@@ -54,7 +52,7 @@ namespace Randomizer.SMZ3 {
                 var patch = new Patch(world, worlds, seedData.Guid, patchRnd);
                 var worldData = new WorldData {
                     Id = world.Id,
-                    Guid = world.Guid.Replace("-", ""),
+                    Guid = world.Guid,
                     Player = world.Player,
                     Patches = patch.Create(config)
                 };

--- a/Randomizer.SMZ3/Randomizer.cs
+++ b/Randomizer.SMZ3/Randomizer.cs
@@ -13,12 +13,12 @@ namespace Randomizer.SMZ3 {
 
             var rnd = new Random(int.Parse(seed));
 
-            var logic = SMLogic.Tournament;
+            var logic = SMLogic.Advanced;
             if (options.ContainsKey("logic")) {
                 logic = options["logic"] switch {
                     "casual" => SMLogic.Casual,
-                    "tournament" => SMLogic.Tournament,
-                    _ => SMLogic.Tournament
+                    "tournament" => SMLogic.Advanced,
+                    _ => SMLogic.Advanced
                 };
             }
 

--- a/Randomizer.SMZ3/Randomizer.cs
+++ b/Randomizer.SMZ3/Randomizer.cs
@@ -6,7 +6,7 @@ namespace Randomizer.SMZ3 {
 
     public class Randomizer : IRandomizer {
 
-        public const string version = "11.0";
+        public static readonly Version version = new Version(11, 0);
 
         public ISeedData GenerateSeed(IDictionary<string, string> options, string seed) {
             int randoSeed;

--- a/Randomizer.SMZ3/Randomizer.cs
+++ b/Randomizer.SMZ3/Randomizer.cs
@@ -6,12 +6,18 @@ namespace Randomizer.SMZ3 {
 
     public class Randomizer : IRandomizer {
 
+        public const string version = "11.0";
+
         public ISeedData GenerateSeed(IDictionary<string, string> options, string seed) {
-            if (seed == "") {
-                seed = new Random().Next().ToString();
+            int randoSeed;
+            if (string.IsNullOrEmpty(seed)) {
+                randoSeed = new Random().Next();
+                seed = randoSeed.ToString();
+            } else {
+                randoSeed = int.Parse(seed);
             }
 
-            var rnd = new Random(int.Parse(seed));
+            var randoRnd = new Random(randoSeed);
 
             var logic = SMLogic.Advanced;
             if (options.ContainsKey("logic")) {
@@ -30,7 +36,7 @@ namespace Randomizer.SMZ3 {
                 worlds.Add(new World(config, options[$"player-{p}"], p, new HexGuid()));
             }
 
-            var filler = new Filler(worlds, config, rnd);
+            var filler = new Filler(worlds, config, randoRnd);
             filler.Fill();
 
             var playthrough = new Playthrough(worlds);
@@ -46,10 +52,10 @@ namespace Randomizer.SMZ3 {
             };
 
             /* Make sure RNG is the same when applying patches to the ROM to have consistent RNG for seed identifer etc */
-            int patchSeed = rnd.Next();
+            int patchSeed = randoRnd.Next();
             foreach (var world in worlds) {
                 var patchRnd = new Random(patchSeed);
-                var patch = new Patch(world, worlds, seedData.Guid, patchRnd);
+                var patch = new Patch(world, worlds, seedData.Guid, randoSeed, patchRnd);
                 var worldData = new WorldData {
                     Id = world.Id,
                     Guid = world.Guid,

--- a/Randomizer.SMZ3/Region.cs
+++ b/Randomizer.SMZ3/Region.cs
@@ -22,8 +22,8 @@ namespace Randomizer.SMZ3 {
     }
 
     abstract class SMRegion : Region {
-        public SMRegion(World world, Config config)
-            : base(world, config) { }
+        public SMLogic Logic => Config.SMLogic;
+        public SMRegion(World world, Config config) : base(world, config) { }
     }
 
     abstract class Z3Region : Region {

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Blue.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Blue.cs
@@ -10,24 +10,24 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
 
         public Blue(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 26, 0x786EC, LocationType.Visible, "Morphing Ball"),
-                new Location(this, 27, 0x7874C, LocationType.Visible, "Power Bomb (blue Brinstar)", Config.Logic switch {
+                new Location(this, 26, 0xC786EC, LocationType.Visible, "Morphing Ball"),
+                new Location(this, 27, 0xC7874C, LocationType.Visible, "Power Bomb (blue Brinstar)", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
-                new Location(this, 28, 0x78798, LocationType.Visible, "Missile (blue Brinstar middle)", Config.Logic switch {
+                new Location(this, 28, 0xC78798, LocationType.Visible, "Missile (blue Brinstar middle)", Config.Logic switch {
                     _ => new Requirement(items => items.Morph)
                 }),
-                new Location(this, 29, 0x7879E, LocationType.Hidden, "Energy Tank, Brinstar Ceiling", Config.Logic switch {
+                new Location(this, 29, 0xC7879E, LocationType.Hidden, "Energy Tank, Brinstar Ceiling", Config.Logic switch {
                     Casual => items => items.CanFly() || items.HiJump ||items.SpeedBooster || items.Ice,
                     _ => new Requirement(items => true)
                 }),
-                new Location(this, 34, 0x78802, LocationType.Chozo, "Missile (blue Brinstar bottom)", Config.Logic switch {
+                new Location(this, 34, 0xC78802, LocationType.Chozo, "Missile (blue Brinstar bottom)", Config.Logic switch {
                     _ => new Requirement(items => items.Morph)
                 }),
-                new Location(this, 36, 0x78836, LocationType.Visible, "Missile (blue Brinstar top)", Config.Logic switch {
+                new Location(this, 36, 0xC78836, LocationType.Visible, "Missile (blue Brinstar top)", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
-                new Location(this, 37, 0x7883C, LocationType.Hidden, "Missile (blue Brinstar behind missile)", Config.Logic switch {
+                new Location(this, 37, 0xC7883C, LocationType.Hidden, "Missile (blue Brinstar behind missile)", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
             };

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Blue.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Blue.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
 
@@ -11,23 +11,23 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
         public Blue(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
                 new Location(this, 26, 0xC786EC, LocationType.Visible, "Morphing Ball"),
-                new Location(this, 27, 0xC7874C, LocationType.Visible, "Power Bomb (blue Brinstar)", Config.Logic switch {
+                new Location(this, 27, 0xC7874C, LocationType.Visible, "Power Bomb (blue Brinstar)", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
-                new Location(this, 28, 0xC78798, LocationType.Visible, "Missile (blue Brinstar middle)", Config.Logic switch {
+                new Location(this, 28, 0xC78798, LocationType.Visible, "Missile (blue Brinstar middle)", Logic switch {
                     _ => new Requirement(items => items.Morph)
                 }),
-                new Location(this, 29, 0xC7879E, LocationType.Hidden, "Energy Tank, Brinstar Ceiling", Config.Logic switch {
+                new Location(this, 29, 0xC7879E, LocationType.Hidden, "Energy Tank, Brinstar Ceiling", Logic switch {
                     Casual => items => items.CanFly() || items.HiJump ||items.SpeedBooster || items.Ice,
                     _ => new Requirement(items => true)
                 }),
-                new Location(this, 34, 0xC78802, LocationType.Chozo, "Missile (blue Brinstar bottom)", Config.Logic switch {
+                new Location(this, 34, 0xC78802, LocationType.Chozo, "Missile (blue Brinstar bottom)", Logic switch {
                     _ => new Requirement(items => items.Morph)
                 }),
-                new Location(this, 36, 0xC78836, LocationType.Visible, "Missile (blue Brinstar top)", Config.Logic switch {
+                new Location(this, 36, 0xC78836, LocationType.Visible, "Missile (blue Brinstar top)", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
-                new Location(this, 37, 0xC7883C, LocationType.Hidden, "Missile (blue Brinstar behind missile)", Config.Logic switch {
+                new Location(this, 37, 0xC7883C, LocationType.Hidden, "Missile (blue Brinstar behind missile)", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
             };

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Green.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Green.cs
@@ -10,32 +10,32 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
 
         public Green(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 13, 0x784AC, LocationType.Chozo, "Power Bomb (green Brinstar bottom)", Config.Logic switch {
+                new Location(this, 13, 0xC784AC, LocationType.Chozo, "Power Bomb (green Brinstar bottom)", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
-                new Location(this, 15, 0x78518, LocationType.Visible, "Missile (green Brinstar below super missile)", Config.Logic switch {
+                new Location(this, 15, 0xC78518, LocationType.Visible, "Missile (green Brinstar below super missile)", Config.Logic switch {
                     _ => new Requirement(items => items.CanPassBombPassages() && items.CanOpenRedDoors())
                 }),
-                new Location(this, 16, 0x7851E, LocationType.Visible, "Super Missile (green Brinstar top)", Config.Logic switch {
+                new Location(this, 16, 0xC7851E, LocationType.Visible, "Super Missile (green Brinstar top)", Config.Logic switch {
                     Casual => items => items.CanOpenRedDoors() && items.SpeedBooster,
                     _ => new Requirement(items => items.CanOpenRedDoors() && (items.Morph || items.SpeedBooster))
                 }),
-                new Location(this, 17, 0x7852C, LocationType.Chozo, "Reserve Tank, Brinstar", Config.Logic switch {
+                new Location(this, 17, 0xC7852C, LocationType.Chozo, "Reserve Tank, Brinstar", Config.Logic switch {
                     Casual => items => items.CanOpenRedDoors() && items.SpeedBooster,
                     _ => new Requirement(items => items.CanOpenRedDoors() && (items.Morph || items.SpeedBooster))
                 }),
-                new Location(this, 18, 0x78532, LocationType.Hidden, "Missile (green Brinstar behind missile)", Config.Logic switch {
+                new Location(this, 18, 0xC78532, LocationType.Hidden, "Missile (green Brinstar behind missile)", Config.Logic switch {
                     Casual => items => items.SpeedBooster && items.CanPassBombPassages() && items.CanOpenRedDoors(),
                     _ => new Requirement(items => (items.CanPassBombPassages() || items.Morph && items.ScrewAttack) && items.CanOpenRedDoors())
                 }),
-                new Location(this, 19, 0x78538, LocationType.Visible, "Missile (green Brinstar behind reserve tank)", Config.Logic switch {
+                new Location(this, 19, 0xC78538, LocationType.Visible, "Missile (green Brinstar behind reserve tank)", Config.Logic switch {
                     Casual => items => items.SpeedBooster && items.CanOpenRedDoors() && items.Morph,
                     _ => new Requirement(items => items.CanOpenRedDoors() && items.Morph)
                 }),
-                new Location(this, 30, 0x787C2, LocationType.Visible, "Energy Tank, Etecoons", Config.Logic switch {
+                new Location(this, 30, 0xC787C2, LocationType.Visible, "Energy Tank, Etecoons", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
-                new Location(this, 31, 0x787D0, LocationType.Visible, "Super Missile (green Brinstar bottom)", Config.Logic switch {
+                new Location(this, 31, 0xC787D0, LocationType.Visible, "Super Missile (green Brinstar bottom)", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.Super)
                 }),
             };

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Green.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Green.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
 
@@ -10,32 +10,32 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
 
         public Green(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 13, 0xC784AC, LocationType.Chozo, "Power Bomb (green Brinstar bottom)", Config.Logic switch {
+                new Location(this, 13, 0xC784AC, LocationType.Chozo, "Power Bomb (green Brinstar bottom)", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
-                new Location(this, 15, 0xC78518, LocationType.Visible, "Missile (green Brinstar below super missile)", Config.Logic switch {
+                new Location(this, 15, 0xC78518, LocationType.Visible, "Missile (green Brinstar below super missile)", Logic switch {
                     _ => new Requirement(items => items.CanPassBombPassages() && items.CanOpenRedDoors())
                 }),
-                new Location(this, 16, 0xC7851E, LocationType.Visible, "Super Missile (green Brinstar top)", Config.Logic switch {
+                new Location(this, 16, 0xC7851E, LocationType.Visible, "Super Missile (green Brinstar top)", Logic switch {
                     Casual => items => items.CanOpenRedDoors() && items.SpeedBooster,
                     _ => new Requirement(items => items.CanOpenRedDoors() && (items.Morph || items.SpeedBooster))
                 }),
-                new Location(this, 17, 0xC7852C, LocationType.Chozo, "Reserve Tank, Brinstar", Config.Logic switch {
+                new Location(this, 17, 0xC7852C, LocationType.Chozo, "Reserve Tank, Brinstar", Logic switch {
                     Casual => items => items.CanOpenRedDoors() && items.SpeedBooster,
                     _ => new Requirement(items => items.CanOpenRedDoors() && (items.Morph || items.SpeedBooster))
                 }),
-                new Location(this, 18, 0xC78532, LocationType.Hidden, "Missile (green Brinstar behind missile)", Config.Logic switch {
+                new Location(this, 18, 0xC78532, LocationType.Hidden, "Missile (green Brinstar behind missile)", Logic switch {
                     Casual => items => items.SpeedBooster && items.CanPassBombPassages() && items.CanOpenRedDoors(),
                     _ => new Requirement(items => (items.CanPassBombPassages() || items.Morph && items.ScrewAttack) && items.CanOpenRedDoors())
                 }),
-                new Location(this, 19, 0xC78538, LocationType.Visible, "Missile (green Brinstar behind reserve tank)", Config.Logic switch {
+                new Location(this, 19, 0xC78538, LocationType.Visible, "Missile (green Brinstar behind reserve tank)", Logic switch {
                     Casual => items => items.SpeedBooster && items.CanOpenRedDoors() && items.Morph,
                     _ => new Requirement(items => items.CanOpenRedDoors() && items.Morph)
                 }),
-                new Location(this, 30, 0xC787C2, LocationType.Visible, "Energy Tank, Etecoons", Config.Logic switch {
+                new Location(this, 30, 0xC787C2, LocationType.Visible, "Energy Tank, Etecoons", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
-                new Location(this, 31, 0xC787D0, LocationType.Visible, "Super Missile (green Brinstar bottom)", Config.Logic switch {
+                new Location(this, 31, 0xC787D0, LocationType.Visible, "Super Missile (green Brinstar bottom)", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.Super)
                 }),
             };

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Kraid.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Kraid.cs
@@ -15,7 +15,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
                     items => !Config.Keysanity || items.KraidKey),
                 new Location(this, 48, 0xC78ACA, LocationType.Chozo, "Varia Suit",
                     items => !Config.Keysanity || items.KraidKey),
-                new Location(this, 44, 0xC789EC, LocationType.Hidden, "Missile (Kraid)", Config.Logic switch {
+                new Location(this, 44, 0xC789EC, LocationType.Hidden, "Missile (Kraid)", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
             };

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Kraid.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Kraid.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.ItemType;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
 
@@ -13,9 +12,9 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
         public Kraid(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
                 new Location(this, 43, 0xC7899C, LocationType.Hidden, "Energy Tank, Kraid",
-                    items => !Config.Keysanity || items.Has(KraidKey)),
+                    items => !Config.Keysanity || items.KraidKey),
                 new Location(this, 48, 0xC78ACA, LocationType.Chozo, "Varia Suit",
-                    items => !Config.Keysanity || items.Has(KraidKey)),
+                    items => !Config.Keysanity || items.KraidKey),
                 new Location(this, 44, 0xC789EC, LocationType.Hidden, "Missile (Kraid)", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Kraid.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Kraid.cs
@@ -12,11 +12,11 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
 
         public Kraid(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 43, 0x7899C, LocationType.Hidden, "Energy Tank, Kraid",
+                new Location(this, 43, 0xC7899C, LocationType.Hidden, "Energy Tank, Kraid",
                     items => !Config.Keysanity || items.Has(KraidKey)),
-                new Location(this, 48, 0x78ACA, LocationType.Chozo, "Varia Suit",
+                new Location(this, 48, 0xC78ACA, LocationType.Chozo, "Varia Suit",
                     items => !Config.Keysanity || items.Has(KraidKey)),
-                new Location(this, 44, 0x789EC, LocationType.Hidden, "Missile (Kraid)", Config.Logic switch {
+                new Location(this, 44, 0xC789EC, LocationType.Hidden, "Missile (Kraid)", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
             };

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Pink.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Pink.cs
@@ -10,27 +10,27 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
 
         public Pink(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 14, 0x784E4, LocationType.Chozo, "Super Missile (pink Brinstar)", Config.Logic switch {
+                new Location(this, 14, 0xC784E4, LocationType.Chozo, "Super Missile (pink Brinstar)", Config.Logic switch {
                     _ => new Requirement(items => items.CanPassBombPassages() && items.Super)
                 }),
-                new Location(this, 21, 0x78608, LocationType.Visible, "Missile (pink Brinstar top)"),
-                new Location(this, 22, 0x7860E, LocationType.Visible, "Missile (pink Brinstar bottom)"),
-                new Location(this, 23, 0x78614, LocationType.Chozo, "Charge Beam", Config.Logic switch {
+                new Location(this, 21, 0xC78608, LocationType.Visible, "Missile (pink Brinstar top)"),
+                new Location(this, 22, 0xC7860E, LocationType.Visible, "Missile (pink Brinstar bottom)"),
+                new Location(this, 23, 0xC78614, LocationType.Chozo, "Charge Beam", Config.Logic switch {
                     _ => new Requirement(items => items.CanPassBombPassages())
                 }),
-                new Location(this, 24, 0x7865C, LocationType.Visible, "Power Bomb (pink Brinstar)", Config.Logic switch {
+                new Location(this, 24, 0xC7865C, LocationType.Visible, "Power Bomb (pink Brinstar)", Config.Logic switch {
                     Casual => items => items.CanUsePowerBombs() && items.Super && items.HasEnergyReserves(1),
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.Super)
                 }),
-                new Location(this, 25, 0x78676, LocationType.Visible, "Missile (green Brinstar pipe)", Config.Logic switch {
+                new Location(this, 25, 0xC78676, LocationType.Visible, "Missile (green Brinstar pipe)", Config.Logic switch {
                     _ => new Requirement(items => items.Morph &&
                         (items.PowerBomb || items.Super || items.CanAccessNorfairUpperPortal()))
                 }),
-                new Location(this, 33, 0x787FA, LocationType.Visible, "Energy Tank, Waterway", Config.Logic switch {
+                new Location(this, 33, 0xC787FA, LocationType.Visible, "Energy Tank, Waterway", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.CanOpenRedDoors() && items.SpeedBooster &&
                         (items.HasEnergyReserves(1) || items.Gravity))
                 }),
-                new Location(this, 35, 0x78824, LocationType.Visible, "Energy Tank, Brinstar Gate", Config.Logic switch {
+                new Location(this, 35, 0xC78824, LocationType.Visible, "Energy Tank, Brinstar Gate", Config.Logic switch {
                     Casual => items => items.CanUsePowerBombs() && items.Wave && items.HasEnergyReserves(1),
                     _ => new Requirement(items => items.CanUsePowerBombs() && (items.Wave || items.Super))
                 }),

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Pink.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Pink.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
 
@@ -10,27 +10,27 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
 
         public Pink(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 14, 0xC784E4, LocationType.Chozo, "Super Missile (pink Brinstar)", Config.Logic switch {
+                new Location(this, 14, 0xC784E4, LocationType.Chozo, "Super Missile (pink Brinstar)", Logic switch {
                     _ => new Requirement(items => items.CanPassBombPassages() && items.Super)
                 }),
                 new Location(this, 21, 0xC78608, LocationType.Visible, "Missile (pink Brinstar top)"),
                 new Location(this, 22, 0xC7860E, LocationType.Visible, "Missile (pink Brinstar bottom)"),
-                new Location(this, 23, 0xC78614, LocationType.Chozo, "Charge Beam", Config.Logic switch {
+                new Location(this, 23, 0xC78614, LocationType.Chozo, "Charge Beam", Logic switch {
                     _ => new Requirement(items => items.CanPassBombPassages())
                 }),
-                new Location(this, 24, 0xC7865C, LocationType.Visible, "Power Bomb (pink Brinstar)", Config.Logic switch {
+                new Location(this, 24, 0xC7865C, LocationType.Visible, "Power Bomb (pink Brinstar)", Logic switch {
                     Casual => items => items.CanUsePowerBombs() && items.Super && items.HasEnergyReserves(1),
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.Super)
                 }),
-                new Location(this, 25, 0xC78676, LocationType.Visible, "Missile (green Brinstar pipe)", Config.Logic switch {
+                new Location(this, 25, 0xC78676, LocationType.Visible, "Missile (green Brinstar pipe)", Logic switch {
                     _ => new Requirement(items => items.Morph &&
                         (items.PowerBomb || items.Super || items.CanAccessNorfairUpperPortal()))
                 }),
-                new Location(this, 33, 0xC787FA, LocationType.Visible, "Energy Tank, Waterway", Config.Logic switch {
+                new Location(this, 33, 0xC787FA, LocationType.Visible, "Energy Tank, Waterway", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.CanOpenRedDoors() && items.SpeedBooster &&
                         (items.HasEnergyReserves(1) || items.Gravity))
                 }),
-                new Location(this, 35, 0xC78824, LocationType.Visible, "Energy Tank, Brinstar Gate", Config.Logic switch {
+                new Location(this, 35, 0xC78824, LocationType.Visible, "Energy Tank, Brinstar Gate", Logic switch {
                     Casual => items => items.CanUsePowerBombs() && items.Wave && items.HasEnergyReserves(1),
                     _ => new Requirement(items => items.CanUsePowerBombs() && (items.Wave || items.Super))
                 }),
@@ -38,7 +38,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
         }
 
         public override bool CanEnter(Progression items) {
-            return Config.Logic switch {
+            return Logic switch {
                 Casual =>
                     items.CanOpenRedDoors() && (items.CanDestroyBombWalls() || items.SpeedBooster) ||
                     items.CanUsePowerBombs() ||

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Red.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Red.cs
@@ -10,24 +10,24 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
 
         public Red(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 38, 0x78876, LocationType.Chozo, "X-Ray Scope", Config.Logic switch {
+                new Location(this, 38, 0xC78876, LocationType.Chozo, "X-Ray Scope", Config.Logic switch {
                     Casual => items => items.CanUsePowerBombs() && items.CanOpenRedDoors() && (items.Grapple || items.SpaceJump),
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.CanOpenRedDoors() && (
                         items.Grapple || items.SpaceJump ||
                         (items.CanIbj() || items.HiJump && items.SpeedBooster || items.CanSpringBallJump()) &&
                             (items.Varia && items.HasEnergyReserves(3) || items.HasEnergyReserves(5))))
                 }),
-                new Location(this, 39, 0x788CA, LocationType.Visible, "Power Bomb (red Brinstar sidehopper room)", Config.Logic switch {
+                new Location(this, 39, 0xC788CA, LocationType.Visible, "Power Bomb (red Brinstar sidehopper room)", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.Super)
                 }),
-                new Location(this, 40, 0x7890E, LocationType.Chozo, "Power Bomb (red Brinstar spike room)", Config.Logic switch {
+                new Location(this, 40, 0xC7890E, LocationType.Chozo, "Power Bomb (red Brinstar spike room)", Config.Logic switch {
                     Casual => items => (items.CanUsePowerBombs() || items.Ice) && items.Super,
                     _ => new Requirement(items => items.Super)
                 }),
-                new Location(this, 41, 0x78914, LocationType.Visible, "Missile (red Brinstar spike room)", Config.Logic switch {
+                new Location(this, 41, 0xC78914, LocationType.Visible, "Missile (red Brinstar spike room)", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.Super)
                 }),
-                new Location(this, 42, 0x7896E, LocationType.Chozo, "Spazer", Config.Logic switch {
+                new Location(this, 42, 0xC7896E, LocationType.Chozo, "Spazer", Config.Logic switch {
                     _ => new Requirement(items => items.CanPassBombPassages() && items.Super)
                 }),
             };

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Red.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Red.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
 
@@ -10,31 +10,31 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
 
         public Red(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 38, 0xC78876, LocationType.Chozo, "X-Ray Scope", Config.Logic switch {
+                new Location(this, 38, 0xC78876, LocationType.Chozo, "X-Ray Scope", Logic switch {
                     Casual => items => items.CanUsePowerBombs() && items.CanOpenRedDoors() && (items.Grapple || items.SpaceJump),
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.CanOpenRedDoors() && (
                         items.Grapple || items.SpaceJump ||
                         (items.CanIbj() || items.HiJump && items.SpeedBooster || items.CanSpringBallJump()) &&
                             (items.Varia && items.HasEnergyReserves(3) || items.HasEnergyReserves(5))))
                 }),
-                new Location(this, 39, 0xC788CA, LocationType.Visible, "Power Bomb (red Brinstar sidehopper room)", Config.Logic switch {
+                new Location(this, 39, 0xC788CA, LocationType.Visible, "Power Bomb (red Brinstar sidehopper room)", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.Super)
                 }),
-                new Location(this, 40, 0xC7890E, LocationType.Chozo, "Power Bomb (red Brinstar spike room)", Config.Logic switch {
+                new Location(this, 40, 0xC7890E, LocationType.Chozo, "Power Bomb (red Brinstar spike room)", Logic switch {
                     Casual => items => (items.CanUsePowerBombs() || items.Ice) && items.Super,
                     _ => new Requirement(items => items.Super)
                 }),
-                new Location(this, 41, 0xC78914, LocationType.Visible, "Missile (red Brinstar spike room)", Config.Logic switch {
+                new Location(this, 41, 0xC78914, LocationType.Visible, "Missile (red Brinstar spike room)", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.Super)
                 }),
-                new Location(this, 42, 0xC7896E, LocationType.Chozo, "Spazer", Config.Logic switch {
+                new Location(this, 42, 0xC7896E, LocationType.Chozo, "Spazer", Logic switch {
                     _ => new Requirement(items => items.CanPassBombPassages() && items.Super)
                 }),
             };
         }
 
         public override bool CanEnter(Progression items) {
-            return Config.Logic switch {
+            return Logic switch {
                 Casual =>
                     (items.CanDestroyBombWalls() || items.SpeedBooster) && items.Super && items.Morph ||
                     items.CanAccessNorfairUpperPortal() && (items.Ice || items.HiJump || items.SpaceJump),

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/Central.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/Central.cs
@@ -10,19 +10,19 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria {
 
         public Central(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 0, 0x781CC, LocationType.Visible, "Power Bomb (Crateria surface)", Config.Logic switch {
+                new Location(this, 0, 0xC781CC, LocationType.Visible, "Power Bomb (Crateria surface)", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.SpeedBooster && items.CanFly())
                 }),
-                new Location(this, 12, 0x78486, LocationType.Visible, "Missile (Crateria middle)", Config.Logic switch {
+                new Location(this, 12, 0xC78486, LocationType.Visible, "Missile (Crateria middle)", Config.Logic switch {
                     _ => new Requirement(items => items.CanPassBombPassages())
                 }),
-                new Location(this, 6, 0x783EE, LocationType.Visible, "Missile (Crateria bottom)", Config.Logic switch {
+                new Location(this, 6, 0xC783EE, LocationType.Visible, "Missile (Crateria bottom)", Config.Logic switch {
                     _ => new Requirement(items => items.CanDestroyBombWalls())
                 }),
-                new Location(this, 11, 0x78478, LocationType.Visible, "Super Missile (Crateria)", Config.Logic switch {
+                new Location(this, 11, 0xC78478, LocationType.Visible, "Super Missile (Crateria)", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.HasEnergyReserves(2) && items.SpeedBooster)
                 }),
-                new Location(this, 7, 0x78404, LocationType.Chozo, "Bombs", Config.Logic switch {
+                new Location(this, 7, 0xC78404, LocationType.Chozo, "Bombs", Config.Logic switch {
                     Casual => items => items.CanPassBombPassages() && items.CanOpenRedDoors(),
                     _ => new Requirement(items => items.Morph && items.CanOpenRedDoors())
                 })

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/Central.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/Central.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria {
 
@@ -10,19 +10,19 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria {
 
         public Central(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 0, 0xC781CC, LocationType.Visible, "Power Bomb (Crateria surface)", Config.Logic switch {
+                new Location(this, 0, 0xC781CC, LocationType.Visible, "Power Bomb (Crateria surface)", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.SpeedBooster && items.CanFly())
                 }),
-                new Location(this, 12, 0xC78486, LocationType.Visible, "Missile (Crateria middle)", Config.Logic switch {
+                new Location(this, 12, 0xC78486, LocationType.Visible, "Missile (Crateria middle)", Logic switch {
                     _ => new Requirement(items => items.CanPassBombPassages())
                 }),
-                new Location(this, 6, 0xC783EE, LocationType.Visible, "Missile (Crateria bottom)", Config.Logic switch {
+                new Location(this, 6, 0xC783EE, LocationType.Visible, "Missile (Crateria bottom)", Logic switch {
                     _ => new Requirement(items => items.CanDestroyBombWalls())
                 }),
-                new Location(this, 11, 0xC78478, LocationType.Visible, "Super Missile (Crateria)", Config.Logic switch {
+                new Location(this, 11, 0xC78478, LocationType.Visible, "Super Missile (Crateria)", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.HasEnergyReserves(2) && items.SpeedBooster)
                 }),
-                new Location(this, 7, 0xC78404, LocationType.Chozo, "Bombs", Config.Logic switch {
+                new Location(this, 7, 0xC78404, LocationType.Chozo, "Bombs", Logic switch {
                     Casual => items => items.CanPassBombPassages() && items.CanOpenRedDoors(),
                     _ => new Requirement(items => items.Morph && items.CanOpenRedDoors())
                 })

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/East.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/East.cs
@@ -10,19 +10,19 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria {
 
         public East(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 1, 0x781E8, LocationType.Visible, "Missile (outside Wrecked Ship bottom)", Config.Logic switch {
+                new Location(this, 1, 0xC781E8, LocationType.Visible, "Missile (outside Wrecked Ship bottom)", Config.Logic switch {
                     Casual => items => items.SpaceJump || items.SpeedBooster || items.Grapple,
                     _ => new Requirement(items => true)
                 }),
-                new Location(this, 2, 0x781EE, LocationType.Hidden, "Missile (outside Wrecked Ship top)", Config.Logic switch {
+                new Location(this, 2, 0xC781EE, LocationType.Hidden, "Missile (outside Wrecked Ship top)", Config.Logic switch {
                     Casual => items => items.Super && items.CanPassBombPassages() && (items.SpaceJump || items.SpeedBooster || items.Grapple),
                     _ => new Requirement(items => items.Super && items.CanPassBombPassages())
                 }),
-                new Location(this, 3, 0x781F4, LocationType.Visible, "Missile (outside Wrecked Ship middle)", Config.Logic switch {
+                new Location(this, 3, 0xC781F4, LocationType.Visible, "Missile (outside Wrecked Ship middle)", Config.Logic switch {
                     Casual => items => items.Super && items.CanPassBombPassages() && (items.SpaceJump || items.SpeedBooster || items.Grapple),
                     _ => new Requirement(items => items.Super && items.CanPassBombPassages())
                 }),
-                new Location(this, 4, 0x78248, LocationType.Visible, "Missile (Crateria moat)", Config.Logic switch {
+                new Location(this, 4, 0xC78248, LocationType.Visible, "Missile (Crateria moat)", Config.Logic switch {
                     Casual => items => items.SpaceJump || items.SpeedBooster || items.Grapple,
                     _ => new Requirement(items => true)
                 }),

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/East.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/East.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria {
 
@@ -10,19 +10,19 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria {
 
         public East(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 1, 0xC781E8, LocationType.Visible, "Missile (outside Wrecked Ship bottom)", Config.Logic switch {
+                new Location(this, 1, 0xC781E8, LocationType.Visible, "Missile (outside Wrecked Ship bottom)", Logic switch {
                     Casual => items => items.SpaceJump || items.SpeedBooster || items.Grapple,
                     _ => new Requirement(items => true)
                 }),
-                new Location(this, 2, 0xC781EE, LocationType.Hidden, "Missile (outside Wrecked Ship top)", Config.Logic switch {
+                new Location(this, 2, 0xC781EE, LocationType.Hidden, "Missile (outside Wrecked Ship top)", Logic switch {
                     Casual => items => items.Super && items.CanPassBombPassages() && (items.SpaceJump || items.SpeedBooster || items.Grapple),
                     _ => new Requirement(items => items.Super && items.CanPassBombPassages())
                 }),
-                new Location(this, 3, 0xC781F4, LocationType.Visible, "Missile (outside Wrecked Ship middle)", Config.Logic switch {
+                new Location(this, 3, 0xC781F4, LocationType.Visible, "Missile (outside Wrecked Ship middle)", Logic switch {
                     Casual => items => items.Super && items.CanPassBombPassages() && (items.SpaceJump || items.SpeedBooster || items.Grapple),
                     _ => new Requirement(items => items.Super && items.CanPassBombPassages())
                 }),
-                new Location(this, 4, 0xC78248, LocationType.Visible, "Missile (Crateria moat)", Config.Logic switch {
+                new Location(this, 4, 0xC78248, LocationType.Visible, "Missile (Crateria moat)", Logic switch {
                     Casual => items => items.SpaceJump || items.SpeedBooster || items.Grapple,
                     _ => new Requirement(items => true)
                 }),

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/West.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/West.cs
@@ -10,16 +10,16 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria {
 
         public West(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 8, 0x78432, LocationType.Visible, "Energy Tank, Terminator"),
-                new Location(this, 5, 0x78264, LocationType.Visible, "Energy Tank, Gauntlet", Config.Logic switch {
+                new Location(this, 8, 0xC78432, LocationType.Visible, "Energy Tank, Terminator"),
+                new Location(this, 5, 0xC78264, LocationType.Visible, "Energy Tank, Gauntlet", Config.Logic switch {
                     Casual => items => CanEnterAndLeaveGauntlet(items) && items.HasEnergyReserves(1),
                     _ => new Requirement(items => CanEnterAndLeaveGauntlet(items))
                 }),
-                new Location(this, 9, 0x78464, LocationType.Visible, "Missile (Crateria gauntlet right)", Config.Logic switch {
+                new Location(this, 9, 0xC78464, LocationType.Visible, "Missile (Crateria gauntlet right)", Config.Logic switch {
                     Casual => items => CanEnterAndLeaveGauntlet(items) && items.CanPassBombPassages() && items.HasEnergyReserves(2),
                     _ => new Requirement(items => CanEnterAndLeaveGauntlet(items) && items.CanPassBombPassages())
                 }),
-                new Location(this, 10, 0x7846A, LocationType.Visible, "Missile (Crateria gauntlet left)", Config.Logic switch {
+                new Location(this, 10, 0xC7846A, LocationType.Visible, "Missile (Crateria gauntlet left)", Config.Logic switch {
                     Casual => items => CanEnterAndLeaveGauntlet(items) && items.CanPassBombPassages() && items.HasEnergyReserves(2),
                     _ => new Requirement(items => CanEnterAndLeaveGauntlet(items) && items.CanPassBombPassages())
                 })

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/West.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/West.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria {
 
@@ -11,15 +11,15 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria {
         public West(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
                 new Location(this, 8, 0xC78432, LocationType.Visible, "Energy Tank, Terminator"),
-                new Location(this, 5, 0xC78264, LocationType.Visible, "Energy Tank, Gauntlet", Config.Logic switch {
+                new Location(this, 5, 0xC78264, LocationType.Visible, "Energy Tank, Gauntlet", Logic switch {
                     Casual => items => CanEnterAndLeaveGauntlet(items) && items.HasEnergyReserves(1),
                     _ => new Requirement(items => CanEnterAndLeaveGauntlet(items))
                 }),
-                new Location(this, 9, 0xC78464, LocationType.Visible, "Missile (Crateria gauntlet right)", Config.Logic switch {
+                new Location(this, 9, 0xC78464, LocationType.Visible, "Missile (Crateria gauntlet right)", Logic switch {
                     Casual => items => CanEnterAndLeaveGauntlet(items) && items.CanPassBombPassages() && items.HasEnergyReserves(2),
                     _ => new Requirement(items => CanEnterAndLeaveGauntlet(items) && items.CanPassBombPassages())
                 }),
-                new Location(this, 10, 0xC7846A, LocationType.Visible, "Missile (Crateria gauntlet left)", Config.Logic switch {
+                new Location(this, 10, 0xC7846A, LocationType.Visible, "Missile (Crateria gauntlet left)", Logic switch {
                     Casual => items => CanEnterAndLeaveGauntlet(items) && items.CanPassBombPassages() && items.HasEnergyReserves(2),
                     _ => new Requirement(items => CanEnterAndLeaveGauntlet(items) && items.CanPassBombPassages())
                 })
@@ -31,7 +31,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria {
         }
 
         private bool CanEnterAndLeaveGauntlet(Progression items) {
-            return Config.Logic switch {
+            return Logic switch {
                 Casual =>
                     items.Morph && (items.CanFly() || items.SpeedBooster) && (
                         items.CanIbj() ||

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
 
@@ -12,65 +12,65 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
 
         public Inner(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 140, 0xC7C4AF, LocationType.Visible, "Super Missile (yellow Maridia)", Config.Logic switch {
+                new Location(this, 140, 0xC7C4AF, LocationType.Visible, "Super Missile (yellow Maridia)", Logic switch {
                     Casual => items => items.CanPassBombPassages(),
                     _ => new Requirement(items => items.CanPassBombPassages() &&
                         (items.Gravity || items.Ice || items.HiJump && items.CanSpringBallJump()))
                 }),
-                new Location(this, 141, 0xC7C4B5, LocationType.Visible, "Missile (yellow Maridia super missile)", Config.Logic switch {
+                new Location(this, 141, 0xC7C4B5, LocationType.Visible, "Missile (yellow Maridia super missile)", Logic switch {
                     Casual => items => items.CanPassBombPassages(),
                     _ => new Requirement(items => items.CanPassBombPassages() &&
                         (items.Gravity || items.Ice || items.HiJump && items.CanSpringBallJump()))
                 }),
-                new Location(this, 142, 0xC7C533, LocationType.Visible, "Missile (yellow Maridia false wall)", Config.Logic switch {
+                new Location(this, 142, 0xC7C533, LocationType.Visible, "Missile (yellow Maridia false wall)", Logic switch {
                     Casual => items => items.CanPassBombPassages(),
                     _ => new Requirement(items => items.CanPassBombPassages() &&
                         (items.Gravity || items.Ice || items.HiJump && items.CanSpringBallJump()))
                 }),
-                new Location(this, 143, 0xC7C559, LocationType.Chozo, "Plasma Beam", Config.Logic switch {
+                new Location(this, 143, 0xC7C559, LocationType.Chozo, "Plasma Beam", Logic switch {
                     Casual => items => CanDefeatDraygon(items) && (items.ScrewAttack || items.Plasma) && (items.HiJump || items.CanFly()),
                     _ => new Requirement(items => CanDefeatDraygon(items) &&
                         (items.Charge && items.HasEnergyReserves(3) || items.ScrewAttack || items.Plasma || items.SpeedBooster) &&
                         (items.HiJump || items.CanSpringBallJump() || items.CanFly() || items.SpeedBooster))
                 }),
-                new Location(this, 144, 0xC7C5DD, LocationType.Visible, "Missile (left Maridia sand pit room)", Config.Logic switch {
+                new Location(this, 144, 0xC7C5DD, LocationType.Visible, "Missile (left Maridia sand pit room)", Logic switch {
                     Casual => items => items.CanPassBombPassages(),
                     _ => new Requirement(items => items.HiJump && (items.SpaceJump || items.CanSpringBallJump()) || items.Gravity)
                 }),
-                new Location(this, 145, 0xC7C5E3, LocationType.Chozo, "Reserve Tank, Maridia", Config.Logic switch {
+                new Location(this, 145, 0xC7C5E3, LocationType.Chozo, "Reserve Tank, Maridia", Logic switch {
                     Casual => items => items.CanPassBombPassages(),
                     _ => new Requirement(items => items.HiJump && (items.SpaceJump || items.CanSpringBallJump()) || items.Gravity)
                 }),
-                new Location(this, 146, 0xC7C5EB, LocationType.Visible, "Missile (right Maridia sand pit room)", Config.Logic switch {
+                new Location(this, 146, 0xC7C5EB, LocationType.Visible, "Missile (right Maridia sand pit room)", Logic switch {
                     Casual => new Requirement(items => true),
                     _ => items => items.HiJump || items.Gravity
                 }),
-                new Location(this, 147, 0xC7C5F1, LocationType.Visible, "Power Bomb (right Maridia sand pit room)", Config.Logic switch {
+                new Location(this, 147, 0xC7C5F1, LocationType.Visible, "Power Bomb (right Maridia sand pit room)", Logic switch {
                     Casual => new Requirement(items => true),
                     _ => items => items.HiJump && items.CanSpringBallJump() || items.Gravity
                 }),
-                new Location(this, 148, 0xC7C603, LocationType.Visible, "Missile (pink Maridia)", Config.Logic switch {
+                new Location(this, 148, 0xC7C603, LocationType.Visible, "Missile (pink Maridia)", Logic switch {
                     Casual => items => items.SpeedBooster,
                     _ => new Requirement(items => items.Gravity)
                 }),
-                new Location(this, 149, 0xC7C609, LocationType.Visible, "Super Missile (pink Maridia)", Config.Logic switch {
+                new Location(this, 149, 0xC7C609, LocationType.Visible, "Super Missile (pink Maridia)", Logic switch {
                     Casual => items => items.SpeedBooster,
                     _ => new Requirement(items => items.Gravity)
                 }),
-                new Location(this, 150, 0xC7C6E5, LocationType.Chozo, "Spring Ball", Config.Logic switch {
+                new Location(this, 150, 0xC7C6E5, LocationType.Chozo, "Spring Ball", Logic switch {
                     Casual => items => items.Grapple && items.CanUsePowerBombs() && (items.SpaceJump || items.HiJump),
                     _ => new Requirement(items => items.Grapple && items.CanUsePowerBombs() && (
                         items.Gravity && (items.CanFly() || items.HiJump) ||
                         items.Ice && items.HiJump && items.CanSpringBallJump() && items.SpaceJump))
                 }),
-                new Location(this, 151, 0xC7C74D, LocationType.Hidden, "Missile (Draygon)", Config.Logic switch {
+                new Location(this, 151, 0xC7C74D, LocationType.Hidden, "Missile (Draygon)", Logic switch {
                     Casual => items => CanDefeatBotwoon(items),
                     _ => new Requirement(items => CanDefeatBotwoon(items) && items.Gravity)
                 }),
-                new Location(this, 152, 0xC7C755, LocationType.Visible, "Energy Tank, Botwoon", Config.Logic switch {
+                new Location(this, 152, 0xC7C755, LocationType.Visible, "Energy Tank, Botwoon", Logic switch {
                     _ => new Requirement(items => CanDefeatBotwoon(items))
                 }),
-                new Location(this, 154, 0xC7C7A7, LocationType.Chozo, "Space Jump", Config.Logic switch {
+                new Location(this, 154, 0xC7C7A7, LocationType.Chozo, "Space Jump", Logic switch {
                     Casual => items => CanDefeatDraygon(items),
                     _ => new Requirement(items => CanDefeatDraygon(items) &&
                         (items.CanFly() || items.SpeedBooster && items.HiJump))
@@ -79,7 +79,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
         }
 
         bool CanDefeatDraygon(Progression items) {
-            return World.Config.Logic switch {
+            return Logic switch {
                 Casual => CanDefeatBotwoon(items) && (!World.Config.Keysanity || items.DraygonKey) &&
                     items.Gravity && (items.SpeedBooster && items.HiJump || items.CanFly()),
                 _ => CanDefeatBotwoon(items) && (!World.Config.Keysanity || items.DraygonKey) &&
@@ -88,14 +88,14 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
         }
 
         bool CanDefeatBotwoon(Progression items) {
-            return World.Config.Logic switch {
+            return Logic switch {
                 Casual => items.SpeedBooster || items.CanAccessMaridiaPortal(World),
                 _ => items.Ice || items.SpeedBooster || items.CanAccessMaridiaPortal(World)
             };
         }
 
         public override bool CanEnter(Progression items) {
-            return Config.Logic switch {
+            return Logic switch {
                 Casual => (
                         World.CanEnter("Norfair Upper West", items) && items.CanUsePowerBombs() &&
                         (items.CanFly() || items.SpeedBooster || items.Grapple)

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.ItemType;
 using static Randomizer.SMZ3.Logic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
@@ -81,9 +80,9 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
 
         bool CanDefeatDraygon(Progression items) {
             return World.Config.Logic switch {
-                Casual => CanDefeatBotwoon(items) && (!World.Config.Keysanity || items.Has(DraygonKey)) &&
+                Casual => CanDefeatBotwoon(items) && (!World.Config.Keysanity || items.DraygonKey) &&
                     items.Gravity && (items.SpeedBooster && items.HiJump || items.CanFly()),
-                _ => CanDefeatBotwoon(items) && (!World.Config.Keysanity || items.Has(DraygonKey)) &&
+                _ => CanDefeatBotwoon(items) && (!World.Config.Keysanity || items.DraygonKey) &&
                     items.Gravity
             };
         }

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
@@ -13,65 +13,65 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
 
         public Inner(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 140, 0x7C4AF, LocationType.Visible, "Super Missile (yellow Maridia)", Config.Logic switch {
+                new Location(this, 140, 0xC7C4AF, LocationType.Visible, "Super Missile (yellow Maridia)", Config.Logic switch {
                     Casual => items => items.CanPassBombPassages(),
                     _ => new Requirement(items => items.CanPassBombPassages() &&
                         (items.Gravity || items.Ice || items.HiJump && items.CanSpringBallJump()))
                 }),
-                new Location(this, 141, 0x7C4B5, LocationType.Visible, "Missile (yellow Maridia super missile)", Config.Logic switch {
+                new Location(this, 141, 0xC7C4B5, LocationType.Visible, "Missile (yellow Maridia super missile)", Config.Logic switch {
                     Casual => items => items.CanPassBombPassages(),
                     _ => new Requirement(items => items.CanPassBombPassages() &&
                         (items.Gravity || items.Ice || items.HiJump && items.CanSpringBallJump()))
                 }),
-                new Location(this, 142, 0x7C533, LocationType.Visible, "Missile (yellow Maridia false wall)", Config.Logic switch {
+                new Location(this, 142, 0xC7C533, LocationType.Visible, "Missile (yellow Maridia false wall)", Config.Logic switch {
                     Casual => items => items.CanPassBombPassages(),
                     _ => new Requirement(items => items.CanPassBombPassages() &&
                         (items.Gravity || items.Ice || items.HiJump && items.CanSpringBallJump()))
                 }),
-                new Location(this, 143, 0x7C559, LocationType.Chozo, "Plasma Beam", Config.Logic switch {
+                new Location(this, 143, 0xC7C559, LocationType.Chozo, "Plasma Beam", Config.Logic switch {
                     Casual => items => CanDefeatDraygon(items) && (items.ScrewAttack || items.Plasma) && (items.HiJump || items.CanFly()),
                     _ => new Requirement(items => CanDefeatDraygon(items) &&
                         (items.Charge && items.HasEnergyReserves(3) || items.ScrewAttack || items.Plasma || items.SpeedBooster) &&
                         (items.HiJump || items.CanSpringBallJump() || items.CanFly() || items.SpeedBooster))
                 }),
-                new Location(this, 144, 0x7C5DD, LocationType.Visible, "Missile (left Maridia sand pit room)", Config.Logic switch {
+                new Location(this, 144, 0xC7C5DD, LocationType.Visible, "Missile (left Maridia sand pit room)", Config.Logic switch {
                     Casual => items => items.CanPassBombPassages(),
                     _ => new Requirement(items => items.HiJump && (items.SpaceJump || items.CanSpringBallJump()) || items.Gravity)
                 }),
-                new Location(this, 145, 0x7C5E3, LocationType.Chozo, "Reserve Tank, Maridia", Config.Logic switch {
+                new Location(this, 145, 0xC7C5E3, LocationType.Chozo, "Reserve Tank, Maridia", Config.Logic switch {
                     Casual => items => items.CanPassBombPassages(),
                     _ => new Requirement(items => items.HiJump && (items.SpaceJump || items.CanSpringBallJump()) || items.Gravity)
                 }),
-                new Location(this, 146, 0x7C5EB, LocationType.Visible, "Missile (right Maridia sand pit room)", Config.Logic switch {
+                new Location(this, 146, 0xC7C5EB, LocationType.Visible, "Missile (right Maridia sand pit room)", Config.Logic switch {
                     Casual => new Requirement(items => true),
                     _ => items => items.HiJump || items.Gravity
                 }),
-                new Location(this, 147, 0x7C5F1, LocationType.Visible, "Power Bomb (right Maridia sand pit room)", Config.Logic switch {
+                new Location(this, 147, 0xC7C5F1, LocationType.Visible, "Power Bomb (right Maridia sand pit room)", Config.Logic switch {
                     Casual => new Requirement(items => true),
                     _ => items => items.HiJump && items.CanSpringBallJump() || items.Gravity
                 }),
-                new Location(this, 148, 0x7C603, LocationType.Visible, "Missile (pink Maridia)", Config.Logic switch {
+                new Location(this, 148, 0xC7C603, LocationType.Visible, "Missile (pink Maridia)", Config.Logic switch {
                     Casual => items => items.SpeedBooster,
                     _ => new Requirement(items => items.Gravity)
                 }),
-                new Location(this, 149, 0x7C609, LocationType.Visible, "Super Missile (pink Maridia)", Config.Logic switch {
+                new Location(this, 149, 0xC7C609, LocationType.Visible, "Super Missile (pink Maridia)", Config.Logic switch {
                     Casual => items => items.SpeedBooster,
                     _ => new Requirement(items => items.Gravity)
                 }),
-                new Location(this, 150, 0x7C6E5, LocationType.Chozo, "Spring Ball", Config.Logic switch {
+                new Location(this, 150, 0xC7C6E5, LocationType.Chozo, "Spring Ball", Config.Logic switch {
                     Casual => items => items.Grapple && items.CanUsePowerBombs() && (items.SpaceJump || items.HiJump),
                     _ => new Requirement(items => items.Grapple && items.CanUsePowerBombs() && (
                         items.Gravity && (items.CanFly() || items.HiJump) ||
                         items.Ice && items.HiJump && items.CanSpringBallJump() && items.SpaceJump))
                 }),
-                new Location(this, 151, 0x7C74D, LocationType.Hidden, "Missile (Draygon)", Config.Logic switch {
+                new Location(this, 151, 0xC7C74D, LocationType.Hidden, "Missile (Draygon)", Config.Logic switch {
                     Casual => items => CanDefeatBotwoon(items),
                     _ => new Requirement(items => CanDefeatBotwoon(items) && items.Gravity)
                 }),
-                new Location(this, 152, 0x7C755, LocationType.Visible, "Energy Tank, Botwoon", Config.Logic switch {
+                new Location(this, 152, 0xC7C755, LocationType.Visible, "Energy Tank, Botwoon", Config.Logic switch {
                     _ => new Requirement(items => CanDefeatBotwoon(items))
                 }),
-                new Location(this, 154, 0x7C7A7, LocationType.Chozo, "Space Jump", Config.Logic switch {
+                new Location(this, 154, 0xC7C7A7, LocationType.Chozo, "Space Jump", Config.Logic switch {
                     Casual => items => CanDefeatDraygon(items),
                     _ => new Requirement(items => CanDefeatDraygon(items) &&
                         (items.CanFly() || items.SpeedBooster && items.HiJump))

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Outer.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Outer.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
 
@@ -10,12 +10,12 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
 
         public Outer(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 136, 0xC7C437, LocationType.Visible, "Missile (green Maridia shinespark)", Config.Logic switch {
+                new Location(this, 136, 0xC7C437, LocationType.Visible, "Missile (green Maridia shinespark)", Logic switch {
                     Casual => items => items.SpeedBooster,
                     _ => new Requirement(items => items.Gravity && items.SpeedBooster)
                 }),
                 new Location(this, 137, 0xC7C43D, LocationType.Visible, "Super Missile (green Maridia)"),
-                new Location(this, 138, 0xC7C47D, LocationType.Visible, "Energy Tank, Mama turtle", Config.Logic switch {
+                new Location(this, 138, 0xC7C47D, LocationType.Visible, "Energy Tank, Mama turtle", Logic switch {
                     Casual => items => items.CanFly() || items.SpeedBooster || items.Grapple,
                     _ => new Requirement(items => items.CanFly() || items.SpeedBooster || items.Grapple ||
                         items.CanSpringBallJump() && (items.Gravity || items.HiJump))
@@ -25,7 +25,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
         }
 
         public override bool CanEnter(Progression items) {
-            return Config.Logic switch {
+            return Logic switch {
                 Casual => (
                         World.CanEnter("Norfair Upper West", items) && items.CanUsePowerBombs() ||
                         items.CanAccessMaridiaPortal(World)

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Outer.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Outer.cs
@@ -10,17 +10,17 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
 
         public Outer(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 136, 0x7C437, LocationType.Visible, "Missile (green Maridia shinespark)", Config.Logic switch {
+                new Location(this, 136, 0xC7C437, LocationType.Visible, "Missile (green Maridia shinespark)", Config.Logic switch {
                     Casual => items => items.SpeedBooster,
                     _ => new Requirement(items => items.Gravity && items.SpeedBooster)
                 }),
-                new Location(this, 137, 0x7C43D, LocationType.Visible, "Super Missile (green Maridia)"),
-                new Location(this, 138, 0x7C47D, LocationType.Visible, "Energy Tank, Mama turtle", Config.Logic switch {
+                new Location(this, 137, 0xC7C43D, LocationType.Visible, "Super Missile (green Maridia)"),
+                new Location(this, 138, 0xC7C47D, LocationType.Visible, "Energy Tank, Mama turtle", Config.Logic switch {
                     Casual => items => items.CanFly() || items.SpeedBooster || items.Grapple,
                     _ => new Requirement(items => items.CanFly() || items.SpeedBooster || items.Grapple ||
                         items.CanSpringBallJump() && (items.Gravity || items.HiJump))
                 }),
-                new Location(this, 139, 0x7C483, LocationType.Hidden, "Missile (green Maridia tatori)"),
+                new Location(this, 139, 0xC7C483, LocationType.Hidden, "Missile (green Maridia tatori)"),
             };
         }
 

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/East.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/East.cs
@@ -13,26 +13,26 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
 
         public East(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 73, 0x78F30, LocationType.Visible, "Missile (Mickey Mouse room)", Config.Logic switch {
+                new Location(this, 73, 0xC78F30, LocationType.Visible, "Missile (Mickey Mouse room)", Config.Logic switch {
                     Casual => new Requirement(items => true),
                     _ => items => items.Morph && items.CanDestroyBombWalls()
                 }),
-                new Location(this, 74, 0x78FCA, LocationType.Visible, "Missile (lower Norfair above fire flea room)"),
-                new Location(this, 75, 0x78FD2, LocationType.Visible, "Power Bomb (lower Norfair above fire flea room)", Config.Logic switch {
+                new Location(this, 74, 0xC78FCA, LocationType.Visible, "Missile (lower Norfair above fire flea room)"),
+                new Location(this, 75, 0xC78FD2, LocationType.Visible, "Power Bomb (lower Norfair above fire flea room)", Config.Logic switch {
                     Casual => new Requirement(items => true),
                     _ => items => items.CanPassBombPassages()
                 }),
-                new Location(this, 76, 0x790C0, LocationType.Visible, "Power Bomb (Power Bombs of shame)", Config.Logic switch {
+                new Location(this, 76, 0xC790C0, LocationType.Visible, "Power Bomb (Power Bombs of shame)", Config.Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
-                new Location(this, 77, 0x79100, LocationType.Visible, "Missile (lower Norfair near Wave Beam)", Config.Logic switch {
+                new Location(this, 77, 0xC79100, LocationType.Visible, "Missile (lower Norfair near Wave Beam)", Config.Logic switch {
                     Casual => new Requirement(items => true),
                     _ => items => items.Morph && items.CanDestroyBombWalls()
                 }),
-                new Location(this, 78, 0x79108, LocationType.Hidden, "Energy Tank, Ridley", Config.Logic switch {
+                new Location(this, 78, 0xC79108, LocationType.Hidden, "Energy Tank, Ridley", Config.Logic switch {
                     _ => new Requirement(items => (!Config.Keysanity || items.Has(RidleyKey)) && items.CanUsePowerBombs() && items.Super)
                 }),
-                new Location(this, 80, 0x79184, LocationType.Visible, "Energy Tank, Firefleas")
+                new Location(this, 80, 0xC79184, LocationType.Visible, "Energy Tank, Firefleas")
             };
         }
 

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/East.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/East.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
 
@@ -12,23 +12,23 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
 
         public East(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 73, 0xC78F30, LocationType.Visible, "Missile (Mickey Mouse room)", Config.Logic switch {
+                new Location(this, 73, 0xC78F30, LocationType.Visible, "Missile (Mickey Mouse room)", Logic switch {
                     Casual => new Requirement(items => true),
                     _ => items => items.Morph && items.CanDestroyBombWalls()
                 }),
                 new Location(this, 74, 0xC78FCA, LocationType.Visible, "Missile (lower Norfair above fire flea room)"),
-                new Location(this, 75, 0xC78FD2, LocationType.Visible, "Power Bomb (lower Norfair above fire flea room)", Config.Logic switch {
+                new Location(this, 75, 0xC78FD2, LocationType.Visible, "Power Bomb (lower Norfair above fire flea room)", Logic switch {
                     Casual => new Requirement(items => true),
                     _ => items => items.CanPassBombPassages()
                 }),
-                new Location(this, 76, 0xC790C0, LocationType.Visible, "Power Bomb (Power Bombs of shame)", Config.Logic switch {
+                new Location(this, 76, 0xC790C0, LocationType.Visible, "Power Bomb (Power Bombs of shame)", Logic switch {
                     _ => new Requirement(items => items.CanUsePowerBombs())
                 }),
-                new Location(this, 77, 0xC79100, LocationType.Visible, "Missile (lower Norfair near Wave Beam)", Config.Logic switch {
+                new Location(this, 77, 0xC79100, LocationType.Visible, "Missile (lower Norfair near Wave Beam)", Logic switch {
                     Casual => new Requirement(items => true),
                     _ => items => items.Morph && items.CanDestroyBombWalls()
                 }),
-                new Location(this, 78, 0xC79108, LocationType.Hidden, "Energy Tank, Ridley", Config.Logic switch {
+                new Location(this, 78, 0xC79108, LocationType.Hidden, "Energy Tank, Ridley", Logic switch {
                     _ => new Requirement(items => (!Config.Keysanity || items.RidleyKey) && items.CanUsePowerBombs() && items.Super)
                 }),
                 new Location(this, 80, 0xC79184, LocationType.Visible, "Energy Tank, Firefleas")
@@ -36,7 +36,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
         }
 
         public override bool CanEnter(Progression items) {
-            return Config.Logic switch {
+            return Logic switch {
                 Casual =>
                     items.Varia && (
                         World.CanEnter("Norfair Upper East", items) && items.CanUsePowerBombs() && items.SpaceJump && items.Gravity ||

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/East.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/East.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.ItemType;
 using static Randomizer.SMZ3.Logic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
@@ -30,7 +29,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
                     _ => items => items.Morph && items.CanDestroyBombWalls()
                 }),
                 new Location(this, 78, 0xC79108, LocationType.Hidden, "Energy Tank, Ridley", Config.Logic switch {
-                    _ => new Requirement(items => (!Config.Keysanity || items.Has(RidleyKey)) && items.CanUsePowerBombs() && items.Super)
+                    _ => new Requirement(items => (!Config.Keysanity || items.RidleyKey) && items.CanUsePowerBombs() && items.Super)
                 }),
                 new Location(this, 80, 0xC79184, LocationType.Visible, "Energy Tank, Firefleas")
             };

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/West.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/West.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
 
@@ -10,18 +10,18 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
 
         public West(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 70, 0xC78E6E, LocationType.Visible, "Missile (Gold Torizo)", Config.Logic switch {
+                new Location(this, 70, 0xC78E6E, LocationType.Visible, "Missile (Gold Torizo)", Logic switch {
                     Casual => items => items.CanUsePowerBombs() && items.SpaceJump && items.Super,
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.SpaceJump && items.Varia && (
                         items.HiJump || items.Gravity ||
                         items.CanAccessNorfairLowerPortal() && (items.CanFly() || items.CanSpringBallJump() || items.SpeedBooster) && items.Super))
                 }),
-                new Location(this, 71, 0xC78E74, LocationType.Hidden, "Super Missile (Gold Torizo)", Config.Logic switch {
+                new Location(this, 71, 0xC78E74, LocationType.Hidden, "Super Missile (Gold Torizo)", Logic switch {
                     Casual => items => items.CanDestroyBombWalls() && (items.Super || items.Charge) &&
                         (items.CanAccessNorfairLowerPortal() || items.SpaceJump && items.CanUsePowerBombs()),
                     _ => new Requirement(items => items.CanDestroyBombWalls() && items.Varia && (items.Super || items.Charge))
                 }),
-                new Location(this, 79, 0xC79110, LocationType.Chozo, "Screw Attack", Config.Logic switch {
+                new Location(this, 79, 0xC79110, LocationType.Chozo, "Screw Attack", Logic switch {
                     Casual => items => items.CanDestroyBombWalls() && (items.SpaceJump && items.CanUsePowerBombs() || items.CanAccessNorfairLowerPortal()),
                     _ => new Requirement(items => items.CanDestroyBombWalls() && (items.Varia || items.CanAccessNorfairLowerPortal()))
                 }),
@@ -29,7 +29,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
         }
 
         public override bool CanEnter(Progression items) {
-            return Config.Logic switch {
+            return Logic switch {
                 Casual =>
                     items.Varia && (
                         World.CanEnter("Norfair Upper East", items) && items.CanUsePowerBombs() && items.SpaceJump && items.Gravity ||

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/West.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/West.cs
@@ -10,18 +10,18 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
 
         public West(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 70, 0x78E6E, LocationType.Visible, "Missile (Gold Torizo)", Config.Logic switch {
+                new Location(this, 70, 0xC78E6E, LocationType.Visible, "Missile (Gold Torizo)", Config.Logic switch {
                     Casual => items => items.CanUsePowerBombs() && items.SpaceJump && items.Super,
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.SpaceJump && items.Varia && (
                         items.HiJump || items.Gravity ||
                         items.CanAccessNorfairLowerPortal() && (items.CanFly() || items.CanSpringBallJump() || items.SpeedBooster) && items.Super))
                 }),
-                new Location(this, 71, 0x78E74, LocationType.Hidden, "Super Missile (Gold Torizo)", Config.Logic switch {
+                new Location(this, 71, 0xC78E74, LocationType.Hidden, "Super Missile (Gold Torizo)", Config.Logic switch {
                     Casual => items => items.CanDestroyBombWalls() && (items.Super || items.Charge) &&
                         (items.CanAccessNorfairLowerPortal() || items.SpaceJump && items.CanUsePowerBombs()),
                     _ => new Requirement(items => items.CanDestroyBombWalls() && items.Varia && (items.Super || items.Charge))
                 }),
-                new Location(this, 79, 0x79110, LocationType.Chozo, "Screw Attack", Config.Logic switch {
+                new Location(this, 79, 0xC79110, LocationType.Chozo, "Screw Attack", Config.Logic switch {
                     Casual => items => items.CanDestroyBombWalls() && (items.SpaceJump && items.CanUsePowerBombs() || items.CanAccessNorfairLowerPortal()),
                     _ => new Requirement(items => items.CanDestroyBombWalls() && (items.Varia || items.CanAccessNorfairLowerPortal()))
                 }),

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/Crocomire.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/Crocomire.cs
@@ -10,27 +10,27 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
 
         public Crocomire(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 52, 0x78BA4, LocationType.Visible, "Energy Tank, Crocomire", Config.Logic switch {
+                new Location(this, 52, 0xC78BA4, LocationType.Visible, "Energy Tank, Crocomire", Config.Logic switch {
                     Casual => items => items.HasEnergyReserves(1) || items.SpaceJump || items.Grapple,
                     _ => new Requirement(items => true)
                 }),
-                new Location(this, 54, 0x78BC0, LocationType.Visible, "Missile (above Crocomire)", Config.Logic switch {
+                new Location(this, 54, 0xC78BC0, LocationType.Visible, "Missile (above Crocomire)", Config.Logic switch {
                     Casual => items => items.CanFly() || items.Grapple || items.HiJump && items.SpeedBooster,
                     _ => new Requirement(items => (items.CanFly() || items.Grapple || items.HiJump &&
                         (items.SpeedBooster || items.CanSpringBallJump() || items.Varia && items.Ice)) && items.CanHellRun())
                 }),
-                new Location(this, 57, 0x78C04, LocationType.Visible, "Power Bomb (Crocomire)", Config.Logic switch {
+                new Location(this, 57, 0xC78C04, LocationType.Visible, "Power Bomb (Crocomire)", Config.Logic switch {
                     Casual => items => items.CanFly() || items.HiJump || items.Grapple,
                     _ => new Requirement(items => true)
                 }),
-                new Location(this, 58, 0x78C14, LocationType.Visible, "Missile (below Crocomire)", Config.Logic switch {
+                new Location(this, 58, 0xC78C14, LocationType.Visible, "Missile (below Crocomire)", Config.Logic switch {
                     _ => new Requirement(items => items.Morph)
                 }),
-                new Location(this, 59, 0x78C2A, LocationType.Visible, "Missile (Grapple Beam)", Config.Logic switch {
+                new Location(this, 59, 0xC78C2A, LocationType.Visible, "Missile (Grapple Beam)", Config.Logic switch {
                     Casual => items => items.Morph && (items.CanFly() || items.SpeedBooster && items.CanUsePowerBombs()),
                     _ => new Requirement(items => items.SpeedBooster || items.Morph && (items.CanFly() || items.Grapple))
                 }),
-                new Location(this, 60, 0x78C36, LocationType.Chozo, "Grapple Beam", Config.Logic switch {
+                new Location(this, 60, 0xC78C36, LocationType.Chozo, "Grapple Beam", Config.Logic switch {
                     Casual => items => items.Morph && (items.CanFly() || items.SpeedBooster && items.CanUsePowerBombs()),
                     _ => new Requirement(items => items.SpaceJump || items.Morph || items.Grapple ||
                         items.HiJump && items.SpeedBooster)

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/Crocomire.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/Crocomire.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
 
@@ -10,27 +10,27 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
 
         public Crocomire(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 52, 0xC78BA4, LocationType.Visible, "Energy Tank, Crocomire", Config.Logic switch {
+                new Location(this, 52, 0xC78BA4, LocationType.Visible, "Energy Tank, Crocomire", Logic switch {
                     Casual => items => items.HasEnergyReserves(1) || items.SpaceJump || items.Grapple,
                     _ => new Requirement(items => true)
                 }),
-                new Location(this, 54, 0xC78BC0, LocationType.Visible, "Missile (above Crocomire)", Config.Logic switch {
+                new Location(this, 54, 0xC78BC0, LocationType.Visible, "Missile (above Crocomire)", Logic switch {
                     Casual => items => items.CanFly() || items.Grapple || items.HiJump && items.SpeedBooster,
                     _ => new Requirement(items => (items.CanFly() || items.Grapple || items.HiJump &&
                         (items.SpeedBooster || items.CanSpringBallJump() || items.Varia && items.Ice)) && items.CanHellRun())
                 }),
-                new Location(this, 57, 0xC78C04, LocationType.Visible, "Power Bomb (Crocomire)", Config.Logic switch {
+                new Location(this, 57, 0xC78C04, LocationType.Visible, "Power Bomb (Crocomire)", Logic switch {
                     Casual => items => items.CanFly() || items.HiJump || items.Grapple,
                     _ => new Requirement(items => true)
                 }),
-                new Location(this, 58, 0xC78C14, LocationType.Visible, "Missile (below Crocomire)", Config.Logic switch {
+                new Location(this, 58, 0xC78C14, LocationType.Visible, "Missile (below Crocomire)", Logic switch {
                     _ => new Requirement(items => items.Morph)
                 }),
-                new Location(this, 59, 0xC78C2A, LocationType.Visible, "Missile (Grapple Beam)", Config.Logic switch {
+                new Location(this, 59, 0xC78C2A, LocationType.Visible, "Missile (Grapple Beam)", Logic switch {
                     Casual => items => items.Morph && (items.CanFly() || items.SpeedBooster && items.CanUsePowerBombs()),
                     _ => new Requirement(items => items.SpeedBooster || items.Morph && (items.CanFly() || items.Grapple))
                 }),
-                new Location(this, 60, 0xC78C36, LocationType.Chozo, "Grapple Beam", Config.Logic switch {
+                new Location(this, 60, 0xC78C36, LocationType.Chozo, "Grapple Beam", Logic switch {
                     Casual => items => items.Morph && (items.CanFly() || items.SpeedBooster && items.CanUsePowerBombs()),
                     _ => new Requirement(items => items.SpaceJump || items.Morph || items.Grapple ||
                         items.HiJump && items.SpeedBooster)
@@ -39,7 +39,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
         }
 
         public override bool CanEnter(Progression items) {
-            return Config.Logic switch {
+            return Logic switch {
                 Casual => (
                         (items.CanDestroyBombWalls() || items.SpeedBooster) && items.Super && items.Morph ||
                         items.CanAccessNorfairUpperPortal()

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/East.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/East.cs
@@ -10,44 +10,44 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
 
         public East(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 49, 0x78AE4, LocationType.Hidden, "Missile (lava room)", Config.Logic switch {
+                new Location(this, 49, 0xC78AE4, LocationType.Hidden, "Missile (lava room)", Config.Logic switch {
                     _ => new Requirement(items => items.Morph)
                 }),
-                new Location(this, 61, 0x78C3E, LocationType.Chozo, "Reserve Tank, Norfair", Config.Logic switch {
+                new Location(this, 61, 0xC78C3E, LocationType.Chozo, "Reserve Tank, Norfair", Config.Logic switch {
                     Casual => items => items.Morph && (
                         items.CanFly() || items.Grapple && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice),
                     _ => new Requirement(items => items.Morph && items.Super)
                 }),
-                new Location(this, 62, 0x78C44, LocationType.Hidden, "Missile (Norfair Reserve Tank)", Config.Logic switch {
+                new Location(this, 62, 0xC78C44, LocationType.Hidden, "Missile (Norfair Reserve Tank)", Config.Logic switch {
                     Casual => items => items.Morph && (
                         items.CanFly() || items.Grapple && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice),
                     _ => new Requirement(items => items.Morph && items.Super)
                 }),
-                new Location(this, 63, 0x78C52, LocationType.Visible, "Missile (bubble Norfair green door)", Config.Logic switch {
+                new Location(this, 63, 0xC78C52, LocationType.Visible, "Missile (bubble Norfair green door)", Config.Logic switch {
                     Casual => items => items.CanFly() ||
                         items.Grapple && items.Morph && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice,
                     _ => new Requirement(items => items.Super)
                 }),
-                new Location(this, 64, 0x78C66, LocationType.Visible, "Missile (bubble Norfair)"),
-                new Location(this, 65, 0x78C74, LocationType.Hidden, "Missile (Speed Booster)", Config.Logic switch {
+                new Location(this, 64, 0xC78C66, LocationType.Visible, "Missile (bubble Norfair)"),
+                new Location(this, 65, 0xC78C74, LocationType.Hidden, "Missile (Speed Booster)", Config.Logic switch {
                     Casual => items => items.CanFly() || items.Morph && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice,
                     _ => new Requirement(items => items.Super)
                 }),
-                new Location(this, 66, 0x78C82, LocationType.Chozo, "Speed Booster", Config.Logic switch {
+                new Location(this, 66, 0xC78C82, LocationType.Chozo, "Speed Booster", Config.Logic switch {
                     Casual => items => items.CanFly() || items.Morph && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice,
                     _ => new Requirement(items => items.Super)
                 }),
-                new Location(this, 67, 0x78CBC, LocationType.Visible, "Missile (Wave Beam)", Config.Logic switch {
+                new Location(this, 67, 0xC78CBC, LocationType.Visible, "Missile (Wave Beam)", Config.Logic switch {
                     Casual => items => items.CanFly() || items.Morph && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice,
                     _ => new Requirement(items => true)
                 }),
-                new Location(this, 68, 0x78CCA, LocationType.Chozo, "Wave Beam", Config.Logic switch {
+                new Location(this, 68, 0xC78CCA, LocationType.Chozo, "Wave Beam", Config.Logic switch {
                     Casual => items => items.Morph && (
                         items.CanFly() || items.Morph && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice),

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/East.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/East.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
 
@@ -10,44 +10,44 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
 
         public East(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 49, 0xC78AE4, LocationType.Hidden, "Missile (lava room)", Config.Logic switch {
+                new Location(this, 49, 0xC78AE4, LocationType.Hidden, "Missile (lava room)", Logic switch {
                     _ => new Requirement(items => items.Morph)
                 }),
-                new Location(this, 61, 0xC78C3E, LocationType.Chozo, "Reserve Tank, Norfair", Config.Logic switch {
+                new Location(this, 61, 0xC78C3E, LocationType.Chozo, "Reserve Tank, Norfair", Logic switch {
                     Casual => items => items.Morph && (
                         items.CanFly() || items.Grapple && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice),
                     _ => new Requirement(items => items.Morph && items.Super)
                 }),
-                new Location(this, 62, 0xC78C44, LocationType.Hidden, "Missile (Norfair Reserve Tank)", Config.Logic switch {
+                new Location(this, 62, 0xC78C44, LocationType.Hidden, "Missile (Norfair Reserve Tank)", Logic switch {
                     Casual => items => items.Morph && (
                         items.CanFly() || items.Grapple && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice),
                     _ => new Requirement(items => items.Morph && items.Super)
                 }),
-                new Location(this, 63, 0xC78C52, LocationType.Visible, "Missile (bubble Norfair green door)", Config.Logic switch {
+                new Location(this, 63, 0xC78C52, LocationType.Visible, "Missile (bubble Norfair green door)", Logic switch {
                     Casual => items => items.CanFly() ||
                         items.Grapple && items.Morph && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice,
                     _ => new Requirement(items => items.Super)
                 }),
                 new Location(this, 64, 0xC78C66, LocationType.Visible, "Missile (bubble Norfair)"),
-                new Location(this, 65, 0xC78C74, LocationType.Hidden, "Missile (Speed Booster)", Config.Logic switch {
+                new Location(this, 65, 0xC78C74, LocationType.Hidden, "Missile (Speed Booster)", Logic switch {
                     Casual => items => items.CanFly() || items.Morph && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice,
                     _ => new Requirement(items => items.Super)
                 }),
-                new Location(this, 66, 0xC78C82, LocationType.Chozo, "Speed Booster", Config.Logic switch {
+                new Location(this, 66, 0xC78C82, LocationType.Chozo, "Speed Booster", Logic switch {
                     Casual => items => items.CanFly() || items.Morph && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice,
                     _ => new Requirement(items => items.Super)
                 }),
-                new Location(this, 67, 0xC78CBC, LocationType.Visible, "Missile (Wave Beam)", Config.Logic switch {
+                new Location(this, 67, 0xC78CBC, LocationType.Visible, "Missile (Wave Beam)", Logic switch {
                     Casual => items => items.CanFly() || items.Morph && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice,
                     _ => new Requirement(items => true)
                 }),
-                new Location(this, 68, 0xC78CCA, LocationType.Chozo, "Wave Beam", Config.Logic switch {
+                new Location(this, 68, 0xC78CCA, LocationType.Chozo, "Wave Beam", Logic switch {
                     Casual => items => items.Morph && (
                         items.CanFly() || items.Morph && (items.SpeedBooster || items.CanPassBombPassages()) ||
                         items.HiJump || items.Ice),
@@ -58,7 +58,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
         }
 
         public override bool CanEnter(Progression items) {
-            return Config.Logic switch {
+            return Logic switch {
                 Casual => (
                         (items.CanDestroyBombWalls() || items.SpeedBooster) && items.Super && items.Morph ||
                         items.CanAccessNorfairUpperPortal()

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/West.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/West.cs
@@ -10,22 +10,22 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
 
         public West(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 50, 0x78B24, LocationType.Chozo, "Ice Beam", Config.Logic switch {
+                new Location(this, 50, 0xC78B24, LocationType.Chozo, "Ice Beam", Config.Logic switch {
                     Casual => items => items.Super && items.CanPassBombPassages() && items.Varia && items.SpeedBooster,
                     _ => new Requirement(items => items.Super && items.Morph && (items.Varia || items.HasEnergyReserves(3)))
                 }),
-                new Location(this, 51, 0x78B46, LocationType.Hidden, "Missile (below Ice Beam)", Config.Logic switch {
+                new Location(this, 51, 0xC78B46, LocationType.Hidden, "Missile (below Ice Beam)", Config.Logic switch {
                     Casual => items => items.Super && items.CanUsePowerBombs() && items.Varia && items.SpeedBooster,
                     _ => new Requirement(items => items.Super && items.CanUsePowerBombs() && (items.Varia || items.HasEnergyReserves(3)) ||
                         items.Varia && items.SpeedBooster && items.Super)
                 }),
-                new Location(this, 53, 0x78BAC, LocationType.Chozo, "Hi-Jump Boots", Config.Logic switch {
+                new Location(this, 53, 0xC78BAC, LocationType.Chozo, "Hi-Jump Boots", Config.Logic switch {
                     _ => new Requirement(items => items.CanOpenRedDoors() && items.CanPassBombPassages())
                 }),
-                new Location(this, 55, 0x78BE6, LocationType.Visible, "Missile (Hi-Jump Boots)", Config.Logic switch {
+                new Location(this, 55, 0xC78BE6, LocationType.Visible, "Missile (Hi-Jump Boots)", Config.Logic switch {
                     _ => new Requirement(items => items.CanOpenRedDoors() && items.Morph)
                 }),
-                new Location(this, 56, 0x78BEC, LocationType.Visible, "Energy Tank (Hi-Jump Boots)", Config.Logic switch {
+                new Location(this, 56, 0xC78BEC, LocationType.Visible, "Energy Tank (Hi-Jump Boots)", Config.Logic switch {
                     _ => new Requirement(items => items.CanOpenRedDoors())
                 }),
             };

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/West.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/West.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
 
@@ -10,22 +10,22 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
 
         public West(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 50, 0xC78B24, LocationType.Chozo, "Ice Beam", Config.Logic switch {
+                new Location(this, 50, 0xC78B24, LocationType.Chozo, "Ice Beam", Logic switch {
                     Casual => items => items.Super && items.CanPassBombPassages() && items.Varia && items.SpeedBooster,
                     _ => new Requirement(items => items.Super && items.Morph && (items.Varia || items.HasEnergyReserves(3)))
                 }),
-                new Location(this, 51, 0xC78B46, LocationType.Hidden, "Missile (below Ice Beam)", Config.Logic switch {
+                new Location(this, 51, 0xC78B46, LocationType.Hidden, "Missile (below Ice Beam)", Logic switch {
                     Casual => items => items.Super && items.CanUsePowerBombs() && items.Varia && items.SpeedBooster,
                     _ => new Requirement(items => items.Super && items.CanUsePowerBombs() && (items.Varia || items.HasEnergyReserves(3)) ||
                         items.Varia && items.SpeedBooster && items.Super)
                 }),
-                new Location(this, 53, 0xC78BAC, LocationType.Chozo, "Hi-Jump Boots", Config.Logic switch {
+                new Location(this, 53, 0xC78BAC, LocationType.Chozo, "Hi-Jump Boots", Logic switch {
                     _ => new Requirement(items => items.CanOpenRedDoors() && items.CanPassBombPassages())
                 }),
-                new Location(this, 55, 0xC78BE6, LocationType.Visible, "Missile (Hi-Jump Boots)", Config.Logic switch {
+                new Location(this, 55, 0xC78BE6, LocationType.Visible, "Missile (Hi-Jump Boots)", Logic switch {
                     _ => new Requirement(items => items.CanOpenRedDoors() && items.Morph)
                 }),
-                new Location(this, 56, 0xC78BEC, LocationType.Visible, "Energy Tank (Hi-Jump Boots)", Config.Logic switch {
+                new Location(this, 56, 0xC78BEC, LocationType.Visible, "Energy Tank (Hi-Jump Boots)", Logic switch {
                     _ => new Requirement(items => items.CanOpenRedDoors())
                 }),
             };

--- a/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.Logic;
+using static Randomizer.SMZ3.SMLogic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid {
 
@@ -13,20 +13,20 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid {
         public WreckedShip(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
                 new Location(this, 128, 0xC7C265, LocationType.Visible, "Missile (Wrecked Ship middle)"),
-                new Location(this, 129, 0xC7C2E9, LocationType.Chozo, "Reserve Tank, Wrecked Ship", Config.Logic switch {
+                new Location(this, 129, 0xC7C2E9, LocationType.Chozo, "Reserve Tank, Wrecked Ship", Logic switch {
                     Casual => items => CanUnlockShip(items) && items.SpeedBooster && items.CanUsePowerBombs() &&
                         (items.Grapple || items.SpaceJump || items.Varia && items.HasEnergyReserves(2) || items.HasEnergyReserves(3)),
                     _ => new Requirement(items => CanUnlockShip(items) && items.CanUsePowerBombs() && items.SpeedBooster &&
                         (items.Varia || items.HasEnergyReserves(2)))
                 }),
-                new Location(this, 130, 0xC7C2EF, LocationType.Visible, "Missile (Gravity Suit)", Config.Logic switch {
+                new Location(this, 130, 0xC7C2EF, LocationType.Visible, "Missile (Gravity Suit)", Logic switch {
                     Casual => items => CanUnlockShip(items) &&
                         (items.Grapple || items.SpaceJump || items.Varia && items.HasEnergyReserves(2) || items.HasEnergyReserves(3)),
                     _ => new Requirement(items => CanUnlockShip(items) && (items.Varia || items.HasEnergyReserves(1)))
                 }),
                 new Location(this, 131, 0xC7C319, LocationType.Visible, "Missile (Wrecked Ship top)",
                     items => CanUnlockShip(items)),
-                new Location(this, 132, 0xC7C337, LocationType.Visible, "Energy Tank, Wrecked Ship", Config.Logic switch {
+                new Location(this, 132, 0xC7C337, LocationType.Visible, "Energy Tank, Wrecked Ship", Logic switch {
                     Casual => items => CanUnlockShip(items) &&
                         (items.HiJump || items.SpaceJump || items.SpeedBooster || items.Gravity),
                     _ => new Requirement(items => CanUnlockShip(items) && (items.Bombs || items.PowerBomb || items.CanSpringBallJump() ||
@@ -36,7 +36,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid {
                     items => CanUnlockShip(items)),
                 new Location(this, 134, 0xC7C365, LocationType.Visible, "Right Super, Wrecked Ship",
                     items => CanUnlockShip(items)),
-                new Location(this, 135, 0xC7C36D, LocationType.Chozo, "Gravity Suit", Config.Logic switch {
+                new Location(this, 135, 0xC7C36D, LocationType.Chozo, "Gravity Suit", Logic switch {
                     Casual => items => CanUnlockShip(items) &&
                         (items.Grapple || items.SpaceJump || items.Varia && items.HasEnergyReserves(2) || items.HasEnergyReserves(3)),
                     _ => new Requirement(items => CanUnlockShip(items) && (items.Varia || items.HasEnergyReserves(1)))
@@ -49,7 +49,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid {
         }
 
         public override bool CanEnter(Progression items) {
-            return Config.Logic switch {
+            return Logic switch {
                 Casual =>
                     items.Super && (
                         items.CanUsePowerBombs() && (items.SpeedBooster || items.Grapple || items.SpaceJump ||

--- a/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.ItemType;
 using static Randomizer.SMZ3.Logic;
 
 namespace Randomizer.SMZ3.Regions.SuperMetroid {
@@ -46,7 +45,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid {
         }
 
         bool CanUnlockShip(Progression items) {
-            return !Config.Keysanity || items.Has(PhantoonKey);
+            return !Config.Keysanity || items.PhantoonKey;
         }
 
         public override bool CanEnter(Progression items) {

--- a/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
@@ -13,31 +13,31 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid {
 
         public WreckedShip(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 128, 0x7C265, LocationType.Visible, "Missile (Wrecked Ship middle)"),
-                new Location(this, 129, 0x7C2E9, LocationType.Chozo, "Reserve Tank, Wrecked Ship", Config.Logic switch {
+                new Location(this, 128, 0xC7C265, LocationType.Visible, "Missile (Wrecked Ship middle)"),
+                new Location(this, 129, 0xC7C2E9, LocationType.Chozo, "Reserve Tank, Wrecked Ship", Config.Logic switch {
                     Casual => items => CanUnlockShip(items) && items.SpeedBooster && items.CanUsePowerBombs() &&
                         (items.Grapple || items.SpaceJump || items.Varia && items.HasEnergyReserves(2) || items.HasEnergyReserves(3)),
                     _ => new Requirement(items => CanUnlockShip(items) && items.CanUsePowerBombs() && items.SpeedBooster &&
                         (items.Varia || items.HasEnergyReserves(2)))
                 }),
-                new Location(this, 130, 0x7C2EF, LocationType.Visible, "Missile (Gravity Suit)", Config.Logic switch {
+                new Location(this, 130, 0xC7C2EF, LocationType.Visible, "Missile (Gravity Suit)", Config.Logic switch {
                     Casual => items => CanUnlockShip(items) &&
                         (items.Grapple || items.SpaceJump || items.Varia && items.HasEnergyReserves(2) || items.HasEnergyReserves(3)),
                     _ => new Requirement(items => CanUnlockShip(items) && (items.Varia || items.HasEnergyReserves(1)))
                 }),
-                new Location(this, 131, 0x7C319, LocationType.Visible, "Missile (Wrecked Ship top)",
+                new Location(this, 131, 0xC7C319, LocationType.Visible, "Missile (Wrecked Ship top)",
                     items => CanUnlockShip(items)),
-                new Location(this, 132, 0x7C337, LocationType.Visible, "Energy Tank, Wrecked Ship", Config.Logic switch {
+                new Location(this, 132, 0xC7C337, LocationType.Visible, "Energy Tank, Wrecked Ship", Config.Logic switch {
                     Casual => items => CanUnlockShip(items) &&
                         (items.HiJump || items.SpaceJump || items.SpeedBooster || items.Gravity),
                     _ => new Requirement(items => CanUnlockShip(items) && (items.Bombs || items.PowerBomb || items.CanSpringBallJump() ||
                         items.HiJump || items.SpaceJump || items.SpeedBooster || items.Gravity))
                 }),
-                new Location(this, 133, 0x7C357, LocationType.Visible, "Super Missile (Wrecked Ship left)",
+                new Location(this, 133, 0xC7C357, LocationType.Visible, "Super Missile (Wrecked Ship left)",
                     items => CanUnlockShip(items)),
-                new Location(this, 134, 0x7C365, LocationType.Visible, "Right Super, Wrecked Ship",
+                new Location(this, 134, 0xC7C365, LocationType.Visible, "Right Super, Wrecked Ship",
                     items => CanUnlockShip(items)),
-                new Location(this, 135, 0x7C36D, LocationType.Chozo, "Gravity Suit", Config.Logic switch {
+                new Location(this, 135, 0xC7C36D, LocationType.Chozo, "Gravity Suit", Config.Logic switch {
                     Casual => items => CanUnlockShip(items) &&
                         (items.Grapple || items.SpaceJump || items.Varia && items.HasEnergyReserves(2) || items.HasEnergyReserves(3)),
                     _ => new Requirement(items => CanUnlockShip(items) && (items.Varia || items.HasEnergyReserves(1)))

--- a/Randomizer.SMZ3/Regions/Zelda/CastleTower.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/CastleTower.cs
@@ -16,7 +16,7 @@ namespace Randomizer.SMZ3.Regions.Zelda {
             Locations = new List<Location> {
                 new Location(this, 256+101, 0xEAB5, LocationType.Regular, "Castle Tower - Foyer"),
                 new Location(this, 256+102, 0xEAB2, LocationType.Regular, "Castle Tower - Dark Maze",
-                    items => items.Lamp && items.Has(KeyCT)),
+                    items => items.Lamp && items.KeyCT >= 1),
             };
         }
 
@@ -25,7 +25,7 @@ namespace Randomizer.SMZ3.Regions.Zelda {
         }
 
         public bool CanComplete(Progression items) {
-            return CanEnter(items) && items.Lamp && items.Has(KeyCT, 2) && items.Sword;
+            return CanEnter(items) && items.Lamp && items.KeyCT >= 2 && items.Sword;
         }
 
     }

--- a/Randomizer.SMZ3/Regions/Zelda/GanonTower.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/GanonTower.cs
@@ -26,16 +26,16 @@ namespace Randomizer.SMZ3.Regions.Zelda {
                 new Location(this, 256+193, 0xEAC1, LocationType.Regular, "Ganon's Tower - DMs Room - Bottom Right",
                     items => items.Hammer && items.Hookshot),
                 new Location(this, 256+194, 0xEAD3, LocationType.Regular, "Ganon's Tower - Map Chest",
-                    items => items.Hammer && (items.Hookshot || items.Boots) && items.Has(KeyGT,
-                        new[] { BigKeyGT, KeyGT }.Contains(Locations.Get("Ganon's Tower - Map Chest").ItemType) ? 3 : 4))
-                    .AlwaysAllow((item, items) => item.Type == KeyGT && items.Has(KeyGT, 3)),
+                    items => items.Hammer && (items.Hookshot || items.Boots) && items.KeyGT >=
+                        (new[] { BigKeyGT, KeyGT }.Contains(Locations.Get("Ganon's Tower - Map Chest").ItemType) ? 3 : 4))
+                    .AlwaysAllow((item, items) => item.Type == KeyGT && items.KeyGT >= 3),
                 new Location(this, 256+195, 0xEAD0, LocationType.Regular, "Ganon's Tower - Firesnake Room",
-                    items => items.Hammer && items.Hookshot && items.Has(KeyGT, new[] {
-                        Locations.Get("Ganon's Tower - Randomizer Room - Top Right"),
-                        Locations.Get("Ganon's Tower - Randomizer Room - Top Left"),
-                        Locations.Get("Ganon's Tower - Randomizer Room - Bottom Left"),
-                        Locations.Get("Ganon's Tower - Randomizer Room - Bottom Right")
-                    }.Any(l => l.ItemType == BigKeyGT) ||
+                    items => items.Hammer && items.Hookshot && items.KeyGT >= (new[] {
+                            Locations.Get("Ganon's Tower - Randomizer Room - Top Right"),
+                            Locations.Get("Ganon's Tower - Randomizer Room - Top Left"),
+                            Locations.Get("Ganon's Tower - Randomizer Room - Bottom Left"),
+                            Locations.Get("Ganon's Tower - Randomizer Room - Bottom Right")
+                        }.Any(l => l.ItemType == BigKeyGT) ||
                         Locations.Get("Ganon's Tower - Firesnake Room").ItemType == KeyGT ? 2 : 3)),
                 new Location(this, 256+196, 0xEAC4, LocationType.Regular, "Ganon's Tower - Randomizer Room - Top Left",
                     items => LeftSide(items, new[] {
@@ -90,11 +90,11 @@ namespace Randomizer.SMZ3.Regions.Zelda {
                         Locations.Get("Ganon's Tower - Compass Room - Bottom Left")
                     })),
                 new Location(this, 256+207, 0xEADF, LocationType.Regular, "Ganon's Tower - Bob's Chest",
-                    items => items.Has(KeyGT, 3) && (
+                    items => items.KeyGT >= 3 && (
                         items.Hammer && items.Hookshot ||
                         items.Somaria && items.Firerod)),
                 new Location(this, 256+208, 0xEAD6, LocationType.Regular, "Ganon's Tower - Big Chest",
-                    items => items.BigKeyGT && items.Has(KeyGT, 3) && (
+                    items => items.BigKeyGT && items.KeyGT >= 3 && (
                         items.Hammer && items.Hookshot ||
                         items.Somaria && items.Firerod))
                     .Allow((item, items) => item.Type != BigKeyGT),
@@ -108,7 +108,7 @@ namespace Randomizer.SMZ3.Regions.Zelda {
                 new Location(this, 256+214, 0xEB03, LocationType.Regular, "Ganon's Tower - Pre-Moldorm Chest", TowerAscend)
                     .Allow((item, items) => item.Type != BigKeyGT),
                 new Location(this, 256+215, 0xEB06, LocationType.Regular, "Ganon's Tower - Moldorm Chest",
-                    items => items.BigKeyGT && items.Has(KeyGT, 4) &&
+                    items => items.BigKeyGT && items.KeyGT >= 4 &&
                         items.Bow && items.CanLightTorches() &&
                         CanBeatMoldorm(items) && items.Hookshot)
                     .Allow((item, items) => new[] { KeyGT, BigKeyGT }.Contains(item.Type) == false),
@@ -116,20 +116,20 @@ namespace Randomizer.SMZ3.Regions.Zelda {
         }
 
         private bool LeftSide(Progression items, IList<Location> locations) {
-            return items.Hammer && items.Hookshot && items.Has(KeyGT, locations.Any(l => l.ItemType == BigKeyGT) ? 3 : 4);
+            return items.Hammer && items.Hookshot && items.KeyGT >= (locations.Any(l => l.ItemType == BigKeyGT) ? 3 : 4);
         }
 
         private bool RightSide(Progression items, IList<Location> locations) {
-            return items.Somaria && items.Firerod && items.Has(KeyGT, locations.Any(l => l.ItemType == BigKeyGT) ? 3 : 4);
+            return items.Somaria && items.Firerod && items.KeyGT >= (locations.Any(l => l.ItemType == BigKeyGT) ? 3 : 4);
         }
 
         private bool BigKeyRoom(Progression items) {
-            return items.Has(KeyGT, 3) && CanBeatArmos(items) 
+            return items.KeyGT >= 3 && CanBeatArmos(items) 
                 && (items.Hammer && items.Hookshot || items.Firerod && items.Somaria);
         }
 
         private bool TowerAscend(Progression items) {
-            return items.BigKeyGT && items.Has(KeyGT, 3) && items.Bow && items.CanLightTorches();
+            return items.BigKeyGT && items.KeyGT >= 3 && items.Bow && items.CanLightTorches();
         }   
             
         private bool CanBeatArmos(Progression items) {

--- a/Randomizer.SMZ3/Regions/Zelda/IcePalace.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/IcePalace.cs
@@ -16,7 +16,7 @@ namespace Randomizer.SMZ3.Regions.Zelda {
             Locations = new List<Location> {
                 new Location(this, 256+161, 0xE9D4, LocationType.Regular, "Ice Palace - Compass Chest"),
                 new Location(this, 256+162, 0xE9E0, LocationType.Regular, "Ice Palace - Spike Room",
-                    items => items.Hookshot || items.BigKeyIP && items.Has(KeyIP)),
+                    items => items.Hookshot || items.BigKeyIP && items.KeyIP >= 1),
                 new Location(this, 256+163, 0xE9DD, LocationType.Regular, "Ice Palace - Map Chest",
                     items => items.Hammer && items.CanLiftLight() && Locations.Get("Ice Palace - Spike Room").Available(items)),
                 new Location(this, 256+164, 0xE9A4, LocationType.Regular, "Ice Palace - Big Key Chest",
@@ -27,7 +27,7 @@ namespace Randomizer.SMZ3.Regions.Zelda {
                     items => items.BigKeyIP),
                 new Location(this, 256+168, 0x180157, LocationType.Regular, "Ice Palace - Kholdstare",
                     items => items.BigKeyIP && items.Hammer && items.CanLiftLight() &&
-                        items.Has(KeyIP, items.Somaria ? 1 : 2)),
+                        items.KeyIP >= (items.Somaria ? 1 : 2)),
             };
         }
 

--- a/Randomizer.SMZ3/Regions/Zelda/LightWorld/DeathMountain/East.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/LightWorld/DeathMountain/East.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using static Randomizer.SMZ3.ItemType;
 
 namespace Randomizer.SMZ3.Regions.Zelda.LightWorld.DeathMountain {
 
@@ -21,7 +20,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld.DeathMountain {
                 new Location(this, 256+11, 0xEB30, LocationType.Regular, "Paradox Cave Lower - Right"),
                 new Location(this, 256+12, 0xEB33, LocationType.Regular, "Paradox Cave Lower - Far Right"),
                 new Location(this, 256+13, 0xE9C5, LocationType.Regular, "Mimic Cave",
-                    items => items.Mirror && items.Has(KeyTR, 2) && World.CanEnter("Turtle Rock", items)),
+                    items => items.Mirror && items.KeyTR >= 2 && World.CanEnter("Turtle Rock", items)),
             };
         }
 

--- a/Randomizer.SMZ3/Regions/Zelda/MiseryMire.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/MiseryMire.cs
@@ -16,17 +16,17 @@ namespace Randomizer.SMZ3.Regions.Zelda {
 
             Locations = new List<Location> {
                 new Location(this, 256+169, 0xEA5E, LocationType.Regular, "Misery Mire - Main Lobby",
-                    items => items.BigKeyMM || items.Has(KeyMM)),
+                    items => items.BigKeyMM || items.KeyMM >= 1),
                 new Location(this, 256+170, 0xEA6A, LocationType.Regular, "Misery Mire - Map Chest",
-                    items => items.BigKeyMM || items.Has(KeyMM)),
+                    items => items.BigKeyMM || items.KeyMM >= 1),
                 new Location(this, 256+171, 0xEA61, LocationType.Regular, "Misery Mire - Bridge Chest"),
                 new Location(this, 256+172, 0xE9DA, LocationType.Regular, "Misery Mire - Spike Chest"),
                 new Location(this, 256+173, 0xEA64, LocationType.Regular, "Misery Mire - Compass Chest",
                     items => items.CanLightTorches() &&
-                        items.Has(KeyMM, Locations.Get("Misery Mire - Big Key Chest").ItemType == BigKeyMM ? 2 : 3)),
+                        items.KeyMM >= (Locations.Get("Misery Mire - Big Key Chest").ItemType == BigKeyMM ? 2 : 3)),
                 new Location(this, 256+174, 0xEA6D, LocationType.Regular, "Misery Mire - Big Key Chest",
                     items => items.CanLightTorches() &&
-                        items.Has(KeyMM, Locations.Get("Misery Mire - Compass Chest").ItemType == BigKeyMM ? 2 : 3)),
+                        items.KeyMM >= (Locations.Get("Misery Mire - Compass Chest").ItemType == BigKeyMM ? 2 : 3)),
                 new Location(this, 256+175, 0xEA67, LocationType.Regular, "Misery Mire - Big Chest",
                     items => items.BigKeyMM),
                 new Location(this, 256+176, 0x180158, LocationType.Regular, "Misery Mire - Vitreous",

--- a/Randomizer.SMZ3/Regions/Zelda/PalaceOfDarkness.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/PalaceOfDarkness.cs
@@ -16,36 +16,36 @@ namespace Randomizer.SMZ3.Regions.Zelda {
             Locations = new List<Location> {
                 new Location(this, 256+121, 0xEA5B, LocationType.Regular, "Palace of Darkness - Shooter Room"),
                 new Location(this, 256+122, 0xEA37, LocationType.Regular, "Palace of Darkness - Big Key Chest",
-                    items => items.Has(KeyPD, Locations.Get("Palace of Darkness - Big Key Chest").ItemType == KeyPD ? 1 :
+                    items => items.KeyPD >= (Locations.Get("Palace of Darkness - Big Key Chest").ItemType == KeyPD ? 1 :
                         items.Hammer && items.Bow && items.Lamp ? 6 : 5))
-                    .AlwaysAllow((item, items) => item.Type == KeyPD && items.Has(KeyPD, 5)),
+                    .AlwaysAllow((item, items) => item.Type == KeyPD && items.KeyPD >= 5),
                 new Location(this, 256+123, 0xEA49, LocationType.Regular, "Palace of Darkness - Stalfos Basement",
-                    items => items.Has(KeyPD) || items.Bow && items.Hammer),
+                    items => items.KeyPD >= 1 || items.Bow && items.Hammer),
                 new Location(this, 256+124, 0xEA3D, LocationType.Regular, "Palace of Darkness - The Arena - Bridge",
-                    items => items.Has(KeyPD) || items.Bow && items.Hammer),
+                    items => items.KeyPD >= 1 || items.Bow && items.Hammer),
                 new Location(this, 256+125, 0xEA3A, LocationType.Regular, "Palace of Darkness - The Arena - Ledge",
                     items => items.Bow),
                 new Location(this, 256+126, 0xEA52, LocationType.Regular, "Palace of Darkness - Map Chest",
                     items => items.Bow),
                 new Location(this, 256+127, 0xEA43, LocationType.Regular, "Palace of Darkness - Compass Chest",
-                    items => items.Has(KeyPD, items.Hammer && items.Bow && items.Lamp ? 4 : 3)),
+                    items => items.KeyPD >= (items.Hammer && items.Bow && items.Lamp ? 4 : 3)),
                 new Location(this, 256+128, 0xEA46, LocationType.Regular, "Palace of Darkness - Harmless Hellway",
-                    items => items.Has(KeyPD, Locations.Get("Palace of Darkness - Harmless Hellway").ItemType == KeyPD ?
+                    items => items.KeyPD >= (Locations.Get("Palace of Darkness - Harmless Hellway").ItemType == KeyPD ?
                         items.Hammer && items.Bow && items.Lamp ? 4 : 3 :
                         items.Hammer && items.Bow && items.Lamp ? 6 : 5))
-                    .AlwaysAllow((item, items) => item.Type == KeyPD && items.Has(KeyPD, 5)),
+                    .AlwaysAllow((item, items) => item.Type == KeyPD && items.KeyPD >= 5),
                 new Location(this, 256+129, 0xEA4C, LocationType.Regular, "Palace of Darkness - Dark Basement - Left",
-                    items => items.Lamp && items.Has(KeyPD, items.Hammer && items.Bow ? 4 : 3)),
+                    items => items.Lamp && items.KeyPD >= (items.Hammer && items.Bow ? 4 : 3)),
                 new Location(this, 256+130, 0xEA4F, LocationType.Regular, "Palace of Darkness - Dark Basement - Right",
-                    items => items.Lamp && items.Has(KeyPD, items.Hammer && items.Bow ? 4 : 3)),
+                    items => items.Lamp && items.KeyPD >= (items.Hammer && items.Bow ? 4 : 3)),
                 new Location(this, 256+131, 0xEA55, LocationType.Regular, "Palace of Darkness - Dark Maze - Top",
-                    items => items.Lamp && items.Has(KeyPD, items.Hammer && items.Bow ? 6 : 5)),
+                    items => items.Lamp && items.KeyPD >= (items.Hammer && items.Bow ? 6 : 5)),
                 new Location(this, 256+132, 0xEA58, LocationType.Regular, "Palace of Darkness - Dark Maze - Bottom",
-                    items => items.Lamp && items.Has(KeyPD, items.Hammer && items.Bow ? 6 : 5)),
+                    items => items.Lamp && items.KeyPD >= (items.Hammer && items.Bow ? 6 : 5)),
                 new Location(this, 256+133, 0xEA40, LocationType.Regular, "Palace of Darkness - Big Chest",
-                    items => items.BigKeyPD && items.Lamp && items.Has(KeyPD, items.Hammer && items.Bow ? 6 : 5)),
+                    items => items.BigKeyPD && items.Lamp && items.KeyPD >= (items.Hammer && items.Bow ? 6 : 5)),
                 new Location(this, 256+134, 0x180153, LocationType.Regular, "Palace of Darkness - Helmasaur King",
-                    items => items.Lamp && items.Hammer && items.Bow && items.BigKeyPD && items.Has(KeyPD, 6)),
+                    items => items.Lamp && items.Hammer && items.Bow && items.BigKeyPD && items.KeyPD >= 6),
             };
         }
 

--- a/Randomizer.SMZ3/Regions/Zelda/SkullWoods.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/SkullWoods.cs
@@ -26,7 +26,7 @@ namespace Randomizer.SMZ3.Regions.Zelda {
                 new Location(this, 256+151, 0xE9FE, LocationType.Regular, "Skull Woods - Bridge Room",
                     items => items.Firerod),
                 new Location(this, 256+152, 0x180155, LocationType.Regular, "Skull Woods - Mothula",
-                    items => items.Firerod && items.Sword && items.Has(KeySW, 3)),
+                    items => items.Firerod && items.Sword && items.KeySW >= 3),
             };
         }
 

--- a/Randomizer.SMZ3/Regions/Zelda/TurtleRock.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/TurtleRock.cs
@@ -21,31 +21,31 @@ namespace Randomizer.SMZ3.Regions.Zelda {
                 new Location(this, 256+179, 0xEA1F, LocationType.Regular, "Turtle Rock - Roller Room - Right",
                     items => items.Firerod),
                 new Location(this, 256+180, 0xEA16, LocationType.Regular, "Turtle Rock - Chain Chomps",
-                    items => items.Has(KeyTR)),
+                    items => items.KeyTR >= 1),
                 new Location(this, 256+181, 0xEA25, LocationType.Regular, "Turtle Rock - Big Key Chest",
-                    items => items.Has(KeyTR,
-                        !Config.Keysanity || Locations.Get("Turtle Rock - Big Key Chest").ItemType == BigKeyTR ? 2 :
+                    items => items.KeyTR >=
+                        (!Config.Keysanity || Locations.Get("Turtle Rock - Big Key Chest").ItemType == BigKeyTR ? 2 :
                             Locations.Get("Turtle Rock - Big Key Chest").ItemType == KeyTR ? 3 : 4))
-                    .AlwaysAllow((item, items) => item.Type == KeyTR && items.Has(KeyTR, 3)),
+                    .AlwaysAllow((item, items) => item.Type == KeyTR && items.KeyTR >= 3),
                 new Location(this, 256+182, 0xEA19, LocationType.Regular, "Turtle Rock - Big Chest",
-                    items => items.BigKeyTR && items.Has(KeyTR, 2))
+                    items => items.BigKeyTR && items.KeyTR >= 2)
                     .Allow((item, items) => item.Type != BigKeyTR),
                 new Location(this, 256+183, 0xEA34, LocationType.Regular, "Turtle Rock - Crystaroller Room",
-                    items => items.BigKeyTR && items.Has(KeyTR, 2)),
+                    items => items.BigKeyTR && items.KeyTR >= 2),
                 new Location(this, 256+184, 0xEA28, LocationType.Regular, "Turtle Rock - Eye Bridge - Top Right", LaserBridge),
                 new Location(this, 256+185, 0xEA2B, LocationType.Regular, "Turtle Rock - Eye Bridge - Top Left", LaserBridge),
                 new Location(this, 256+186, 0xEA2E, LocationType.Regular, "Turtle Rock - Eye Bridge - Bottom Right", LaserBridge),
                 new Location(this, 256+187, 0xEA31, LocationType.Regular, "Turtle Rock - Eye Bridge - Bottom Left", LaserBridge),
                 new Location(this, 256+188, 0x180159, LocationType.Regular, "Turtle Rock - Trinexx",
-                    items => items.BigKeyTR && items.Has(KeyTR, 4) && items.Lamp && CanBeatBoss(items)),
+                    items => items.BigKeyTR && items.KeyTR >= 4 && items.Lamp && CanBeatBoss(items)),
             };
         }
 
-        private bool LaserBridge(Progression items) {
-            return items.BigKeyTR && items.Has(KeyTR, 3) && items.Lamp && (items.Cape || items.Byrna || items.CanBlockLasers);
+        bool LaserBridge(Progression items) {
+            return items.BigKeyTR && items.KeyTR >= 3 && items.Lamp && (items.Cape || items.Byrna || items.CanBlockLasers);
         }
 
-        private bool CanBeatBoss(Progression items) {
+        bool CanBeatBoss(Progression items) {
             return items.Firerod && items.Icerod;
         }
 

--- a/Randomizer.SMZ3/Version.cs
+++ b/Randomizer.SMZ3/Version.cs
@@ -1,0 +1,18 @@
+﻿namespace Randomizer.SMZ3 {
+
+    public class Version {
+
+        public int Major { get; }
+        public int Minor { get; }
+
+        public Version(int major, int minor) {
+            Major = major;
+            Minor = minor;
+        }
+
+        public override string ToString() => $"{Major}.{Minor}";
+        public static implicit operator string(Version version) => version.ToString();
+
+    }
+
+}

--- a/Randomizer.SMZ3/World.cs
+++ b/Randomizer.SMZ3/World.cs
@@ -15,11 +15,11 @@ namespace Randomizer.SMZ3 {
         public string Guid { get; set; }
         public int Id { get; set; }
 
-        public World(Config config, string player, int id) {
+        public World(Config config, string player, int id, string guid) {
             Config = config;
             Player = player;
             Id = id;
-            Guid = System.Guid.NewGuid().ToString();
+            Guid = guid;
 
             Regions = new List<Region> {
                 new Regions.Zelda.CastleTower(this, Config),


### PR DESCRIPTION
The game title follows the format `ZSM[version][Z3 logic][SM logic][seed number]`. This includes the data that directly identifies seed compatibility and item distribution.

The version (in the format `[major number].[minor number]`, e.g. "11.0) contributes to identifying the available logic sets.

The Z3 logic is currently one of `N`, `G`, `M`, for nmg, owg, and mg, respectively.
The SM logic is currently one of `C`, `B`, `A`, for casual, basic, advanced, respectively. This is an optimistic preparation for possible new logic. Casual correspond to current normal logic, and advanced correspond to hard. However, the "casual", and "tournament" keys in the options mapping remain unchanged for now.

The seed number is expressed in hexadecimal to preserve characters. If the version is assumed to take up five characters (two digits for each number, plus a dot), then safely there is three more unused characters in the title.

A binary representation of these data are added to the SM rom header in a similar manner.