### PR TITLE
Do not store null file data

### DIFF
--- a/WebRandomizer/ClientApp/src/components/Upload.jsx
+++ b/WebRandomizer/ClientApp/src/components/Upload.jsx
@@ -54,8 +54,10 @@ export default function Upload(props) {
         }
 
         try {
-            await localForage.setItem('baseRomSM', new Blob([fileDataSM]));
-            await localForage.setItem('baseRomLTTP', new Blob([fileDataZ3]));
+            if (fileDataSM)
+                await localForage.setItem('baseRomSM', new Blob([fileDataSM]));
+            if (fileDataZ3)
+                await localForage.setItem('baseRomLTTP', new Blob([fileDataZ3]));
         } catch (error) {
             console.log("Could not store file to localforage:", error);
             return;


### PR DESCRIPTION
When storing file data to `localForage` in Upload we must avoid storing the initial null value in the case a subset of files are required (such as for SM only rando).

We might want to consider a later commit which makes the SMZ3 page only ask for the Z3 rom file if an SM rom file was already entered from the SM page.