### PR TITLE
Actually add custom triforce room text

### DIFF
--- a/Randomizer.SMZ3/Patch.cs
+++ b/Randomizer.SMZ3/Patch.cs
@@ -535,6 +535,7 @@ namespace Randomizer.SMZ3 {
 
             var triforceRoom = Texts.TriforceRoom(rnd);
             patches.Add((Snes(0x308400), Dialog.Simple(triforceRoom)));
+            stringTable.SetTriforceRoomText(triforceRoom);
         }
 
         void WriteStringTable() {

--- a/Randomizer.SMZ3/Text/StringTable.cs
+++ b/Randomizer.SMZ3/Text/StringTable.cs
@@ -36,6 +36,10 @@ namespace Randomizer.SMZ3.Text {
             SetText("ganon_phase_3", text);
         }
 
+        public void SetTriforceRoomText(string text) {
+            SetText("end_triforce", "{NOBORDER}\n" + text);
+        }
+
         public void SetPedestalText(string text) {
             SetText("mastersword_pedestal_translated", text);
         }


### PR DESCRIPTION
The first custom text is (almost) the same as the default text. It turns out `end_triforce` has to be changed in the string table for anything to change at all.