### PR TITLE
Guard IP "east wing" against worst key use

### DIFF
--- a/Randomizer.SMZ3/Regions/Zelda/IcePalace.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/IcePalace.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using static Randomizer.SMZ3.ItemType;
 
 namespace Randomizer.SMZ3.Regions.Zelda {
@@ -15,11 +16,24 @@ namespace Randomizer.SMZ3.Regions.Zelda {
             Locations = new List<Location> {
                 new Location(this, 256+161, 0x1E9D4, LocationType.Regular, "Ice Palace - Compass Chest"),
                 new Location(this, 256+162, 0x1E9E0, LocationType.Regular, "Ice Palace - Spike Room",
-                    items => items.Hookshot || items.BigKeyIP && items.KeyIP >= 1),
+                    items => items.Hookshot || items.KeyIP >= 1 && CanNotWasteKeysBeforeAccessible(items, new[] {
+                        Locations.Get("Ice Palace - Map Chest"),
+                        Locations.Get("Ice Palace - Big Key Chest")
+                    })),
                 new Location(this, 256+163, 0x1E9DD, LocationType.Regular, "Ice Palace - Map Chest",
-                    items => items.Hammer && items.CanLiftLight() && Locations.Get("Ice Palace - Spike Room").Available(items)),
+                    items => items.Hammer && items.CanLiftLight() && (
+                        items.Hookshot || items.KeyIP >= 1 && CanNotWasteKeysBeforeAccessible(items, new[] {
+                            Locations.Get("Ice Palace - Spike Room"),
+                            Locations.Get("Ice Palace - Big Key Chest")
+                        })
+                    )),
                 new Location(this, 256+164, 0x1E9A4, LocationType.Regular, "Ice Palace - Big Key Chest",
-                    items => items.Hammer && items.CanLiftLight() && Locations.Get("Ice Palace - Spike Room").Available(items)),
+                    items => items.Hammer && items.CanLiftLight() && (
+                        items.Hookshot || items.KeyIP >= 1 && CanNotWasteKeysBeforeAccessible(items, new[] {
+                            Locations.Get("Ice Palace - Spike Room"),
+                            Locations.Get("Ice Palace - Map Chest")
+                        })
+                    )),
                 new Location(this, 256+165, 0x1E9E3, LocationType.Regular, "Ice Palace - Iced T Room"),
                 new Location(this, 256+166, 0x1E995, LocationType.Regular, "Ice Palace - Freezor Chest"),
                 new Location(this, 256+167, 0x1E9AA, LocationType.Regular, "Ice Palace - Big Chest",
@@ -28,6 +42,10 @@ namespace Randomizer.SMZ3.Regions.Zelda {
                     items => items.BigKeyIP && items.Hammer && items.CanLiftLight() &&
                         items.KeyIP >= (items.Somaria ? 1 : 2)),
             };
+        }
+
+        bool CanNotWasteKeysBeforeAccessible(Progression items, IList<Location> locations) {
+            return !items.BigKeyIP || locations.Any(l => l.ItemIs(BigKeyIP, World));
         }
 
         public override bool CanEnter(Progression items) {


### PR DESCRIPTION
Changes the logic for the three "east wing" locations to be on par with Z3r v31.0.4