### PR TITLE
Add seed generation settings to the database

### DIFF
--- a/WebRandomizer/ClientApp/src/components/Multiworld.jsx
+++ b/WebRandomizer/ClientApp/src/components/Multiworld.jsx
@@ -51,7 +51,14 @@ export default function Multiworld(props) {
         <div>
             {session.guid && <Seed session={session} sessionStatus={sessionStatus} onRegisterPlayer={onRegisterPlayer} />}
             <br />
-            {clientData !== null && <Patch gameId={session.data.seed.gameId} world={session.data.seed.worlds.find(world => world.worldId === clientData.worldId)} fileName={`${session.data.seed.gameName} - ${session.data.seed.seedNumber} - ${clientData.name}.sfc`} />}
+            {clientData !== null && (
+                <Patch
+                    gameId={session.data.seed.gameId}
+                    gameType={session.data.seed.type}
+                    seedNumber={session.data.seed.seedNumber}
+                    world={session.data.seed.worlds.find(world => world.worldId === clientData.worldId)}
+                />
+            )}
             <br />
             {clientData !== null && <Connection clientData={clientData} device={device} onConnect={onConnect} onDeviceSelect={onDeviceSelect} />}
             <br />

--- a/WebRandomizer/ClientApp/src/components/Multiworld.jsx
+++ b/WebRandomizer/ClientApp/src/components/Multiworld.jsx
@@ -51,14 +51,7 @@ export default function Multiworld(props) {
         <div>
             {session.guid && <Seed session={session} sessionStatus={sessionStatus} onRegisterPlayer={onRegisterPlayer} />}
             <br />
-            {clientData !== null && (
-                <Patch
-                    gameId={session.data.seed.gameId}
-                    gameType={session.data.seed.type}
-                    seedNumber={session.data.seed.seedNumber}
-                    world={session.data.seed.worlds.find(world => world.worldId === clientData.worldId)}
-                />
-            )}
+            {clientData !== null && <Patch seed={session.data.seed} world={session.data.seed.worlds.find(world => world.worldId === clientData.worldId)} />}
             <br />
             {clientData !== null && <Connection clientData={clientData} device={device} onConnect={onConnect} onDeviceSelect={onDeviceSelect} />}
             <br />

--- a/WebRandomizer/ClientApp/src/components/Patch.jsx
+++ b/WebRandomizer/ClientApp/src/components/Patch.jsx
@@ -5,6 +5,7 @@ import { Label, Button, Input, InputGroupAddon, InputGroupText } from 'reactstra
 import BootstrapSwitchButton from 'bootstrap-switch-button-react';
 import InputGroup from './util/PrefixInputGroup';
 import DropdownSelect from './util/DropdownSelect';
+import DownloadInfoTooltip from './util/DownloadInfoTooltip';
 import Upload from './Upload';
 
 import { prepareRom } from '../file/rom';
@@ -222,8 +223,9 @@ export default function Patch(props) {
                 </Col>
             </Row>
             <Row>
-                <Col md="6">
+                <Col className="d-flex align-items-center" md="6">
                     <Button color="primary" onClick={onDownloadRom}>Download ROM</Button>
+                    <DownloadInfoTooltip className="ml-2" gameId={gameId} />
                 </Col>
             </Row>
         </Form>

--- a/WebRandomizer/ClientApp/src/components/Permalink.jsx
+++ b/WebRandomizer/ClientApp/src/components/Permalink.jsx
@@ -47,7 +47,7 @@ export default function Permalink(props) {
                                     <Col>Type: {seed.type}</Col>
                                 </Row>
                                 <br />
-                                <Patch gameId={seed.gameId} world={seed.worlds[0]} fileName={`${seed.gameName} - ${seed.seedNumber}.sfc`} />
+                                <Patch gameId={seed.gameId} gameType={seed.type} seedNumber={seed.seedNumber} world={seed.worlds[0]} />
                             </CardBody>
                         </Card>
                         {seed !== null && <Spoiler seedData={seed} />}

--- a/WebRandomizer/ClientApp/src/components/Permalink.jsx
+++ b/WebRandomizer/ClientApp/src/components/Permalink.jsx
@@ -40,14 +40,13 @@ export default function Permalink(props) {
                                 <Row>
                                     <Col>Seed: {props.match.params.seed_id}</Col>
                                 </Row>
-                                <Row>
-                                    <Col>Seed number: {seed.seedNumber}</Col>
-                                </Row>
-                                <Row>
-                                    <Col>Type: {seed.type}</Col>
-                                </Row>
+                                {seed.seedNumber && (
+                                    <Row>
+                                        <Col>Seed number: {seed.seedNumber}</Col>
+                                    </Row>
+                                )}
                                 <br />
-                                <Patch gameId={seed.gameId} gameType={seed.type} seedNumber={seed.seedNumber} world={seed.worlds[0]} />
+                                <Patch seed={seed} world={seed.worlds[0]} />
                             </CardBody>
                         </Card>
                         {seed !== null && <Spoiler seedData={seed} />}

--- a/WebRandomizer/ClientApp/src/components/util/BootstrapIcon.jsx
+++ b/WebRandomizer/ClientApp/src/components/util/BootstrapIcon.jsx
@@ -1,0 +1,25 @@
+﻿import React from 'react';
+import styled from 'styled-components';
+
+// through bootstrap "$primary" -> "$blue"
+const primary = '#007bff';
+
+const StyledIcon = styled.div`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  color: ${primary};
+
+  & > * {
+    width: 1em;
+    height: 1em;
+  }
+`;
+
+export default function BootstrapIcon({ id, children }) {
+    return (
+        <StyledIcon id={id}>
+            {children}
+        </StyledIcon>
+    );
+}

--- a/WebRandomizer/ClientApp/src/components/util/DownloadInfoTooltip.jsx
+++ b/WebRandomizer/ClientApp/src/components/util/DownloadInfoTooltip.jsx
@@ -1,0 +1,97 @@
+﻿import React from 'react';
+import styled, { createGlobalStyle } from 'styled-components';
+import { UncontrolledTooltip } from 'reactstrap';
+import BootstrapIcon from './BootstrapIcon';
+import Markdown from '../Markdown';
+
+const smz3Tooltip = `
+Filename parts legend:
+
+* \`SMZ3\`: Super Metroid / Link to the Past Randomizer
+* \`V\`: Major.Minor version
+* \`ZL+SL\`: LttP and SM logic
+  * LttP: Normal, \`n\`
+  * SM: Normal, \`n\`, or Hard, \`h\`
+* \`S\`: Sword location
+  * Randomized if missing
+  * On Link's Uncle if \`u\`
+  * Early location if \`e\`
+* \`M\`: Morph location
+  * Randomized if missing
+  * Original location if \`o\`
+  * Early location if \`e\`
+* Seed number, or seed guid for race roms
+* Player name for Multiworld roms
+`;
+
+const smTooltip = `
+Filename parts legend:
+
+* \`SM\`: Super Metroid Randomizer
+* \`V\`: Major.Minor version
+* \`L\`: Logic
+  * Casual if \`c\`
+  * Tournament if \`t\`
+* \`I\`: Item placement
+  * Major/Minor split if \`s\`
+  * Full randomization if \`f\`
+* Seed number, or seed guid for race roms
+* Player name for Multiworld roms
+`;
+
+const tooltipWidth = '350px';
+
+const tooltip_modifiers = {
+    adjustStyle: {
+        enabled: true, order: 875,
+        fn: (data) => ({ ...data, styles: { ...data.styles, maxWidth: tooltipWidth } })
+    }
+};
+
+const TooltipStyling = createGlobalStyle`
+  .rom-info .tooltip-inner {
+    max-width: ${tooltipWidth}
+  }
+`;
+
+const StyledMarkdown = styled(Markdown)`
+  text-align: left;
+  color: silver;
+
+  code {
+    font-size: 100%;
+    color: white;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+
+    ul {
+      padding-left: 2em;
+    }
+  }
+`;
+
+export default function DownloadInfoTooltip({ gameId, ...props }) {
+    return (
+        <div {...props}>
+            <InfoIcon id="download-tooltip" />
+            <TooltipStyling/>
+            <UncontrolledTooltip className="rom-info" modifiers={tooltip_modifiers} placement="right" target="download-tooltip">
+                <StyledMarkdown text={{ smz3: smz3Tooltip, sm: smTooltip }[gameId]} />
+            </UncontrolledTooltip>
+        </div>
+    );
+}
+
+/* https://github.com/twbs/icons/blob/v1.0.0-alpha3/icons/info-circle-fill.svg */
+function InfoIcon({ id }) {
+    return (
+        <BootstrapIcon id={id}>
+            <svg viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                <path fillRule="evenodd" clipRule="evenodd" d="M8 16A8 8 0 108 0a8 8 0 000 16zm.93-9.412l-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM8 5.5a1 1 0 100-2 1 1 0 000 2z" />
+            </svg>
+        </BootstrapIcon>
+    );
+}

--- a/WebRandomizer/ClientApp/src/logiclog/LogicLog.jsx
+++ b/WebRandomizer/ClientApp/src/logiclog/LogicLog.jsx
@@ -29,7 +29,7 @@ const StyledMarkdown = styled(Markdown)`
     padding: 0;
 
     ul {
-      ul { padding: 0 1em; }
+      ul { padding-left: 1em; }
 
       li:before {
         content: "";

--- a/WebRandomizer/Controllers/RandomizerController.cs
+++ b/WebRandomizer/Controllers/RandomizerController.cs
@@ -73,7 +73,7 @@ namespace WebRandomizer.Controllers {
                     var world = new World {
                         WorldId = seedWorld.Id,
                         Guid = seedWorld.Guid,
-                        Logic = seedData.Logic,
+                        Settings = JsonConvert.SerializeObject(options),
                         Player = seedWorld.Player,
                         Patch = ConvertPatch(seedWorld.Patches)
                     };

--- a/WebRandomizer/Controllers/RandomizerController.cs
+++ b/WebRandomizer/Controllers/RandomizerController.cs
@@ -69,6 +69,12 @@ namespace WebRandomizer.Controllers {
                     Worlds = new List<World>()
                 };
 
+                /* If race mode is enabled, blank out the seed number to not reveal it to the client */
+                if (options.ContainsKey("race") && options["race"] == "true") {
+                    seed.SeedNumber = "";
+                    options["seed"] = "";
+                }
+
                 foreach (var seedWorld in seedData.Worlds) {
                     var world = new World {
                         WorldId = seedWorld.Id,

--- a/WebRandomizer/Controllers/RandomizerController.cs
+++ b/WebRandomizer/Controllers/RandomizerController.cs
@@ -60,6 +60,7 @@ namespace WebRandomizer.Controllers {
                 /* Store this seed to the database */
                 var seed = new Seed {
                     GameName = seedData.Game,
+                    GameVersion = randomizer.Version.ToString(),
                     GameId = randomizer.Id,
                     Guid = seedData.Guid,
                     Players = seedData.Worlds.Count,

--- a/WebRandomizer/Controllers/RandomizerController.cs
+++ b/WebRandomizer/Controllers/RandomizerController.cs
@@ -65,7 +65,7 @@ namespace WebRandomizer.Controllers {
                     Players = seedData.Worlds.Count,
                     SeedNumber = seedData.Seed,
                     Spoiler = JsonConvert.SerializeObject(seedData.Playthrough),
-                    Type = seedData.Mode,
+                    Mode = seedData.Mode,
                     Worlds = new List<World>()
                 };
 

--- a/WebRandomizer/Migrations/20200331220405_ChangeLogicToSettings.Designer.cs
+++ b/WebRandomizer/Migrations/20200331220405_ChangeLogicToSettings.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebRandomizer.Models;
@@ -9,9 +10,10 @@ using WebRandomizer.Models;
 namespace WebRandomizer.Migrations
 {
     [DbContext(typeof(RandomizerContext))]
-    partial class RandomizerContextModelSnapshot : ModelSnapshot
+    [Migration("20200331220405_ChangeLogicToSettings")]
+    partial class ChangeLogicToSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WebRandomizer/Migrations/20200331220405_ChangeLogicToSettings.cs
+++ b/WebRandomizer/Migrations/20200331220405_ChangeLogicToSettings.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace WebRandomizer.Migrations
+{
+    public partial class ChangeLogicToSettings : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Logic",
+                table: "Worlds");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Settings",
+                table: "Worlds",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Settings",
+                table: "Worlds");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Logic",
+                table: "Worlds",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/WebRandomizer/Migrations/20200403180848_ChangeSeedTypeToMode.Designer.cs
+++ b/WebRandomizer/Migrations/20200403180848_ChangeSeedTypeToMode.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebRandomizer.Models;
@@ -9,9 +10,10 @@ using WebRandomizer.Models;
 namespace WebRandomizer.Migrations
 {
     [DbContext(typeof(RandomizerContext))]
-    partial class RandomizerContextModelSnapshot : ModelSnapshot
+    [Migration("20200403180848_ChangeSeedTypeToMode")]
+    partial class ChangeSeedTypeToMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WebRandomizer/Migrations/20200403180848_ChangeSeedTypeToMode.cs
+++ b/WebRandomizer/Migrations/20200403180848_ChangeSeedTypeToMode.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace WebRandomizer.Migrations
+{
+    public partial class ChangeSeedTypeToMode : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Type",
+                table: "Seeds");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Mode",
+                table: "Seeds",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Mode",
+                table: "Seeds");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Type",
+                table: "Seeds",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/WebRandomizer/Migrations/20200403183043_AddVersionToSeed.Designer.cs
+++ b/WebRandomizer/Migrations/20200403183043_AddVersionToSeed.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebRandomizer.Models;
@@ -9,9 +10,10 @@ using WebRandomizer.Models;
 namespace WebRandomizer.Migrations
 {
     [DbContext(typeof(RandomizerContext))]
-    partial class RandomizerContextModelSnapshot : ModelSnapshot
+    [Migration("20200403183043_AddVersionToSeed")]
+    partial class AddVersionToSeed
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WebRandomizer/Migrations/20200403183043_AddVersionToSeed.cs
+++ b/WebRandomizer/Migrations/20200403183043_AddVersionToSeed.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace WebRandomizer.Migrations
+{
+    public partial class AddVersionToSeed : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "GameVersion",
+                table: "Seeds",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GameVersion",
+                table: "Seeds");
+        }
+    }
+}

--- a/WebRandomizer/Models/Seed.cs
+++ b/WebRandomizer/Models/Seed.cs
@@ -11,6 +11,7 @@ namespace WebRandomizer.Models {
         public string SeedNumber { get; set; }
         public string Spoiler { get; set; }
         public string GameName { get; set; }
+        public string GameVersion { get; set; }
         public string GameId { get; set; }
         public int Players { get; set; }
         public List<World> Worlds { get; set; }

--- a/WebRandomizer/Models/Seed.cs
+++ b/WebRandomizer/Models/Seed.cs
@@ -7,7 +7,7 @@ namespace WebRandomizer.Models {
     public class Seed {
         public int Id { get; set; }
         public string Guid { get; set; }
-        public string Type { get; set; }
+        public string Mode { get; set; }
         public string SeedNumber { get; set; }
         public string Spoiler { get; set; }
         public string GameName { get; set; }

--- a/WebRandomizer/Models/World.cs
+++ b/WebRandomizer/Models/World.cs
@@ -11,7 +11,7 @@ namespace WebRandomizer.Models {
         public int SeedId { get; set; }
         public string Guid { get; set; }
         public string Player { get; set; }
-        public string Logic { get; set; }
+        public string Settings { get; set; }
         public byte[] Patch { get; set; }
     }
 


### PR DESCRIPTION
This changes the "Logic" field on the "World" entity into "Settings" to be used for storing the settings used at seed generation time so we can display it back on permalinks and use it to generate things like the seed filename,