### PR TITLE
Make eslint happy

### DIFF
--- a/WebRandomizer/ClientApp/.env
+++ b/WebRandomizer/ClientApp/.env
@@ -1,0 +1,1 @@
+﻿EXTEND_ESLINT=true

--- a/WebRandomizer/ClientApp/package.json
+++ b/WebRandomizer/ClientApp/package.json
@@ -36,6 +36,15 @@
     "eject": "react-scripts eject",
     "lint": "eslint ./src/"
   },
+  "eslintConfig": {
+    "extends": "react-app",
+    "plugins": [
+      "react-hooks"
+    ],
+    "rules": {
+      "no-mixed-operators": "off"
+    }
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/WebRandomizer/ClientApp/src/components/Configure.jsx
+++ b/WebRandomizer/ClientApp/src/components/Configure.jsx
@@ -18,12 +18,13 @@ const InputWithoutSpinner = styled(Input)`
 `;
 
 export default function Configure(props) {
+    const randomizer_id = props.match.params.randomizer_id;
+
     const [options, setOptions] = useState(null);
     const [names, setNames] = useState({});
     const [modal, setModal] = useState(false);
     const [randomizer, setRandomizer] = useState(null);
     const [errorMessage, setErrorMessage] = useState(null);
-    const randomizer_id = props.match.params.randomizer_id;
 
     useEffect(() => {
         const fetchData = async () => {
@@ -42,7 +43,7 @@ export default function Configure(props) {
         };
 
         fetchData();
-    }, []);
+    }, []); /* eslint-disable-line react-hooks/exhaustive-deps */
 
     async function createGame(e) {
         e.preventDefault();
@@ -95,68 +96,54 @@ export default function Configure(props) {
 
     if (randomizer) {
         const formOptions = randomizer.options.map(opt => {
-            let inputElement = null;
-            switch (opt.type) {
-                case 'seed':
-                    inputElement = (
-                        <Col key={opt.key} md="6">
-                            <InputGroup>
-                                <InputGroupAddon addonType="prepend">
-                                    <InputGroupText>{opt.description}</InputGroupText>
-                                </InputGroupAddon>
-                                <InputWithoutSpinner type="number" id={opt.key} min={0} max={0x7FFF_FFFF} value={options[opt.key]}
-                                    onChange={(e) => updateOption(opt.key, e.target.value)}
-                                />
-                            </InputGroup>
-                        </Col>
-                    );
-                    break;
-                case 'dropdown':
-                    inputElement = (
-                        <Col key={opt.key} md="6">
-                            <InputGroup>
-                                <InputGroupAddon addonType="prepend">
-                                    <InputGroupText>{opt.description}</InputGroupText>
-                                </InputGroupAddon>
-                                <Input type="select" id={opt.key} value={options[opt.key]} onChange={(e) => updateOption(opt.key, e.target.value)}>
-                                    {Object.entries(opt.values).map(([k,v]) => <option key={k} value={k}>{v}</option>)}
-                                </Input>
-                            </InputGroup>
-                        </Col>
-                    );
-                    break;
-                case 'checkbox':
-                    inputElement = (
-                        <Col key={opt.key} md="6">
-                            <InputGroup>
-                                <InputGroupAddon addonType="prepend">
-                                    <InputGroupText>{opt.description}</InputGroupText>
-                                </InputGroupAddon>
-                                &nbsp;
-                                <BootstrapSwitchButton id={opt.key} onlabel="Yes" offlabel="No" width="80" checked={options[opt.key]}
-                                    onChange={checked => updateOption(opt.key, checked.toString())}
-                                />
-                            </InputGroup>
-                        </Col>
-                    );
-                    break;
-                case 'players':
-                    if (options["gamemode"] === "multiworld") {
-                        inputElement = (
-                            <Col key={opt.key} md="6">
-                                <InputGroup>
-                                    <InputGroupAddon addonType="prepend">
-                                        <InputGroupText>{opt.description}</InputGroupText>
-                                    </InputGroupAddon>
-                                    <Input id={opt.key} value={options[opt.key]} onChange={(e) => updateOption(opt.key, e.target.value)} />
-                                </InputGroup>
-                            </Col>
-                        );
-                    }
-                    break;
-            }
-
-            return inputElement;
+            return opt.type === 'seed' ? (
+                <Col key={opt.key} md="6">
+                    <InputGroup>
+                        <InputGroupAddon addonType="prepend">
+                            <InputGroupText>{opt.description}</InputGroupText>
+                        </InputGroupAddon>
+                        <InputWithoutSpinner type="number" id={opt.key} min={0} max={0x7FFF_FFFF} value={options[opt.key]}
+                            onChange={(e) => updateOption(opt.key, e.target.value)}
+                        />
+                    </InputGroup>
+                </Col>
+            )
+            : opt.type === 'dropdown' ? (
+                <Col key={opt.key} md="6">
+                    <InputGroup>
+                        <InputGroupAddon addonType="prepend">
+                            <InputGroupText>{opt.description}</InputGroupText>
+                        </InputGroupAddon>
+                        <Input type="select" id={opt.key} value={options[opt.key]} onChange={(e) => updateOption(opt.key, e.target.value)}>
+                            {Object.entries(opt.values).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
+                        </Input>
+                    </InputGroup>
+                </Col>
+            )
+            : opt.type === 'checkbox' ? (
+                <Col key={opt.key} md="6">
+                    <InputGroup>
+                        <InputGroupAddon addonType="prepend">
+                            <InputGroupText>{opt.description}</InputGroupText>
+                        </InputGroupAddon>
+                        &nbsp;
+                        <BootstrapSwitchButton id={opt.key} onlabel="Yes" offlabel="No" width="80" checked={options[opt.key]}
+                            onChange={checked => updateOption(opt.key, checked.toString())}
+                        />
+                    </InputGroup>
+                </Col>
+            )
+            : opt.type === 'players' && options["gamemode"] === "multiworld" ? (
+                <Col key={opt.key} md="6">
+                    <InputGroup>
+                        <InputGroupAddon addonType="prepend">
+                            <InputGroupText>{opt.description}</InputGroupText>
+                        </InputGroupAddon>
+                        <Input id={opt.key} value={options[opt.key]} onChange={(e) => updateOption(opt.key, e.target.value)} />
+                    </InputGroup>
+                </Col>
+            )
+            : null;
         });
 
         const formOptionGroups = chunk(formOptions, 2);

--- a/WebRandomizer/ClientApp/src/components/Multiworld.jsx
+++ b/WebRandomizer/ClientApp/src/components/Multiworld.jsx
@@ -27,7 +27,7 @@ export default function Multiworld(props) {
             network.current.start();
             return () => network.current.stop();
         }
-    }, []);
+    }, []); /* eslint-disable-line react-hooks/exhaustive-deps */
 
     function onRegisterPlayer(clientGuid) {
         localStorage.setItem('clientGuid', clientGuid);

--- a/WebRandomizer/ClientApp/src/components/Patch.jsx
+++ b/WebRandomizer/ClientApp/src/components/Patch.jsx
@@ -89,7 +89,7 @@ export default function Patch(props) {
                 setPatchState('download');
             }
         });
-    }, [patchState]);
+    }, [patchState, game.z3]);
 
     useEffect(() => {
         let settings;
@@ -103,7 +103,7 @@ export default function Patch(props) {
             setZ3HeartBeep(defaultTo(z3_heart_beep, 'half'));
             setSMEnergyBeep(defaultTo(sm_energy_beep, true));
         }
-    }, []);
+    }, []); /* eslint-disable-line react-hooks/exhaustive-deps */
 
     async function onDownloadRom() {
         try {

--- a/WebRandomizer/ClientApp/src/components/Permalink.jsx
+++ b/WebRandomizer/ClientApp/src/components/Permalink.jsx
@@ -12,6 +12,7 @@ import attempt from 'lodash/attempt';
 export default function Permalink(props) {
     const seedSlug = props.match.params.seed_id;
     const seedGuid = decode(seedSlug).replace(/-/g, "");
+
     const [seed, setSeed] = useState(null);
     const [errorMessage, setErrorMessage] = useState(null);
 
@@ -29,7 +30,7 @@ export default function Permalink(props) {
                 setErrorMessage(error.toString());
             }
         })
-    }, []);
+    }, []); /* eslint-disable-line react-hooks/exhaustive-deps */
 
     let content;
     if (seed) {


### PR DESCRIPTION
- Ignore no-mixed-operators globally, because relying on operator priority between `&&` and `||` should be just fine.
- Ignored empty dep array for one time `useEffect`s, because that's a perfectly valid usage pattern according to the react docs.
- Replaced switch with a trinary operator chain in `Configure`, so that there is no default case to be missing to begin with.