### PR TITLE
Fix Croc access through Bubble Mountain

### DIFF
--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/Crocomire.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/Crocomire.cs
@@ -47,7 +47,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
                     items.Varia && items.Super && (
                         items.CanUsePowerBombs() && items.SpeedBooster ||
                         items.SpeedBooster && items.Wave ||
-                        items.Morph && (items.CanFly() || items.HiJump) && items.Gravity && items.Wave
+                        items.Morph && (items.CanFly() || items.HiJump) && (items.CanPassBombPassages() || items.Gravity) && items.Wave
                     ),
                 _ => (
                         (items.CanDestroyBombWalls() || items.SpeedBooster) && items.Super && items.Morph ||


### PR DESCRIPTION
CanPassBombPassages in Bubble Mountain has been missing from Normal since the beginning. When we added the Gravity requirement for going through Volcano Room, it accidently made going through Bubble Mountain to Croc require Grav in general.