### PR TITLE
Adjust Mire Portal Access

### DIFF
--- a/Randomizer.SMZ3/Item.cs
+++ b/Randomizer.SMZ3/Item.cs
@@ -613,8 +613,10 @@ namespace Randomizer.SMZ3 {
                 Normal =>
                     items.Varia && items.Super && (items.Gravity && items.SpaceJump) && items.CanUsePowerBombs(),
                 _ =>
-                    items.Varia && items.Super && (items.Gravity || items.HiJump) && items.CanUsePowerBombs()
-            };
+                    items.Varia && items.Super && (
+                        items.CanFly() || items.HiJump || items.SpeedBooster || items.CanSpringBallJump() || items.Ice
+                   ) && (items.Gravity || items.HiJump) && items.CanUsePowerBombs()
+             };
         }
 
         public static bool CanIbj(this Progression items) {


### PR DESCRIPTION
Accessing Mire Portal was missing jump assist in pre-Cathedral in Hard.