### PR TITLE
Allow Registration To Multiple Multiworlds Simultaneously

### DIFF
--- a/WebRandomizer/ClientApp/src/components/Multiworld.jsx
+++ b/WebRandomizer/ClientApp/src/components/Multiworld.jsx
@@ -25,14 +25,13 @@ export default function Multiworld(props) {
         });
 
         if (sessionGuid) {
-            localStorage.setItem('sessionGuid', sessionGuid);
             network.current.start();
             return () => network.current.stop();
         }
     }, []); /* eslint-disable-line react-hooks/exhaustive-deps */
 
-    function onRegisterPlayer(clientGuid) {
-        localStorage.setItem('clientGuid', clientGuid);
+    function onRegisterPlayer(sessionGuid, clientGuid) {
+        localStorage.setItem(sessionGuid, clientGuid);
         network.current.onRegisterPlayer(clientGuid);
     }
 

--- a/WebRandomizer/ClientApp/src/components/Seed.jsx
+++ b/WebRandomizer/ClientApp/src/components/Seed.jsx
@@ -30,7 +30,7 @@ export default function Seed(props) {
                         return (<Col key={`player-${i}`} md="3">
                             <h5>{world.player}</h5>
                             {client == null ?
-                                <Button color="primary" onClick={() => onRegisterPlayer(world.guid)}>Register as this player</Button> :
+                                <Button color="primary" onClick={() => onRegisterPlayer(session.guid, world.guid)}>Register as this player</Button> :
                                 <Button disabled color={client.state < 5 ? 'secondary' : client.state === 5 ? 'warning' : 'success'}>
                                     {client.state < 5 ? 'Registered' : client.state === 5 ? 'Connected' : 'Ready'}
                                 </Button>

--- a/WebRandomizer/ClientApp/src/network/index.js
+++ b/WebRandomizer/ClientApp/src/network/index.js
@@ -121,10 +121,18 @@ export default class Network {
 
                 /* Check if we have locally stored client data, so we can register back to the session */
                 if (this.clientData === null) {
-                    const clientGuid = localStorage.getItem('clientGuid');
-                    const sessionGuid = localStorage.getItem('sessionGuid');
-                    if (sessionGuid === this.session.guid && clientGuid !== null && clientGuid !== '') {
-                        /* The stored session matches and we have a client id, register as this player */
+                    let clientGuid = localStorage.getItem(this.session.guid);
+                    /* Backwards compatibility with old lookup to avoid players losing their sessions
+                       This can be removed once enough time has elapsed */
+                    if (clientGuid === null || clientGuid === '') {
+                        const sessionGuid = localStorage.getItem('sessionGuid');
+                        if (sessionGuid === this.session.guid) {
+                            clientGuid = localStorage.getItem('clientGuid');
+                        }
+                    }
+                    /* End backwards compatibile lookup */
+                    if (clientGuid !== null && clientGuid !== '') {
+                        /* We have a client id for the current session, register as this player */
                         const client = await this.connection.invoke('RegisterPlayer', this.session.guid, clientGuid);
                         if (client !== null) {
                             this.clientData = client;


### PR DESCRIPTION
This PR addresses Issue https://github.com/tewtal/SMZ3Randomizer/issues/91

The change was extremely minor in scope, however in implementing it I realized this would break connection for anybody who had an existing incomplete session.

As a result, over half of this code change is dedicated to backwards compatibility. I tried to clearly mark that chunk of code so that it could be deleted entirely once enough time has elapsed and it's reasonably certain that all old sessions are completed/abandoned.

I'll be happy to address any feedback or concerns you may have, just let me know!