### PR TITLE
Fix Space Jump requirements

### DIFF
--- a/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
@@ -71,9 +71,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
                     _ => new Requirement(items => CanDefeatBotwoon(items))
                 }),
                 new Location(this, 154, 0x8FC7A7, LocationType.Chozo, "Space Jump", Logic switch {
-                    Normal => items => CanDefeatDraygon(items),
-                    _ => new Requirement(items => CanDefeatDraygon(items) &&
-                        (items.CanFly() || items.SpeedBooster && items.HiJump))
+                    _ => new Requirement(items => CanDefeatDraygon(items))
                 })
             };
         }


### PR DESCRIPTION
The Hard and Normal requirements for Space Jump got inverted in the C# conversion. However, they are just a repeat of the CanDefeatDraygon bool, so no additional definition is needed.