### PR TITLE
Resolve the traits of the supported games early

### DIFF
--- a/WebRandomizer/ClientApp/src/App.jsx
+++ b/WebRandomizer/ClientApp/src/App.jsx
@@ -35,6 +35,8 @@ export default function App() {
                         <Route path="/information" render={(props) => <Markdown {...props} source={gameId === 'sm' ? SmInformationMd : Smz3InformationMd} />} />
                         <Route path="/resources" render={(props) => <Markdown {...props} source={ResourcesMd} />} />
                         <Route path="/changelog" render={(props) => <Markdown {...props} source={gameId === 'sm' ? SmChangelogMd : Smz3ChangelogMd} />} />
+                        <Route exact path="/configure" component={Configure} />
+                        {/* Todo: Remove this game specific configure path in v12 */}
                         <Route path="/configure/:randomizer_id" component={Configure} />
                         <Route path="/multiworld/:session_id" component={Multiworld} />
                         <Route path="/seed/:seed_id" component={Permalink} />

--- a/WebRandomizer/ClientApp/src/App.jsx
+++ b/WebRandomizer/ClientApp/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { Suspense, lazy } from 'react';
 import { Route, Switch } from 'react-router';
 import Layout from './components/Layout';
-import Home from './components/Home';
+import Smz3Home from './components/Smz3Home';
 import SmHome from './components/SmHome';
 
 import MultiworldInstructionsMd from './resources/markdown/mwinstructions.md';
@@ -11,6 +11,9 @@ import ResourcesMd from './resources/markdown/resources.md';
 import Smz3ChangelogMd from './resources/markdown/smz3changelog.md';
 import SmChangelogMd from './resources/markdown/smchangelog.md';
 
+import { GameTraitsCtx, resolveGameTraits } from './game/traits';
+import { resolveGameId } from './site';
+
 const LogicLog = lazy(() => import('./logiclog/LogicLog'));
 const Markdown = lazy(() => import('./components/Markdown'));
 const Configure = lazy(() => import('./components/Configure'));
@@ -18,23 +21,26 @@ const Multiworld = lazy(() => import('./components/Multiworld'));
 const Permalink = lazy(() => import('./components/Permalink'));
 
 export default function App() {
-    const gameId = window.location.hostname.startsWith('sm.') ? "sm" : "smz3";
+    const gameId = resolveGameId(document.location.href);
+    const traits = resolveGameTraits(gameId);
 
     return (
-        <Layout gameId={gameId}>
-            <Suspense fallback={<div></div>}>
-                <Switch>
-                    <Route exact path="/" component={gameId === "smz3" ? Home : SmHome} />
-                    <Route path="/logic" component={LogicLog} />
-                    <Route path="/mwinstructions" render={(props) => <Markdown {...props} source={MultiworldInstructionsMd} />} />
-                    <Route path="/information" render={(props) => <Markdown {...props} source={gameId === "smz3" ? Smz3InformationMd : SmInformationMd} />} />
-                    <Route path="/resources" render={(props) => <Markdown {...props} source={ResourcesMd} />} />
-                    <Route path="/changelog" render={(props) => <Markdown {...props} source={gameId === "smz3" ? Smz3ChangelogMd : SmChangelogMd} />} />
-                    <Route path="/configure/:randomizer_id" component={Configure} />
-                    <Route path="/multiworld/:session_id" component={Multiworld} />
-                    <Route path="/seed/:seed_id" component={Permalink} />
-                </Switch>
-            </Suspense>
-        </Layout>
+        <GameTraitsCtx.Provider value={traits}>
+            <Layout>
+                <Suspense fallback={<div></div>}>
+                    <Switch>
+                        <Route exact path="/" component={gameId === 'sm' ? SmHome : Smz3Home} />
+                        <Route path="/logic" component={LogicLog} />
+                        <Route path="/mwinstructions" render={(props) => <Markdown {...props} source={MultiworldInstructionsMd} />} />
+                        <Route path="/information" render={(props) => <Markdown {...props} source={gameId === 'sm' ? SmInformationMd : Smz3InformationMd} />} />
+                        <Route path="/resources" render={(props) => <Markdown {...props} source={ResourcesMd} />} />
+                        <Route path="/changelog" render={(props) => <Markdown {...props} source={gameId === 'sm' ? SmChangelogMd : Smz3ChangelogMd} />} />
+                        <Route path="/configure/:randomizer_id" component={Configure} />
+                        <Route path="/multiworld/:session_id" component={Multiworld} />
+                        <Route path="/seed/:seed_id" component={Permalink} />
+                    </Switch>
+                </Suspense>
+            </Layout>
+        </GameTraitsCtx.Provider>
     );
 }

--- a/WebRandomizer/ClientApp/src/components/Configure.jsx
+++ b/WebRandomizer/ClientApp/src/components/Configure.jsx
@@ -30,15 +30,16 @@ const InputWithoutSpinner = styled(Input)`
 `;
 
 export default function Configure(props) {
-    const gameId = props.match.params.randomizer_id;
+    const game = useContext(GameTraitsCtx)
+
+    // Todo: Remove the game specific configure path in v12
+    const gameId = props.match.params.randomizer_id || game.id;
 
     const [options, setOptions] = useState(null);
     const [names, setNames] = useState({});
     const [randomizer, setRandomizer] = useState(null);
     const [modal, setModal] = useState(false);
     const [errorMessage, setErrorMessage] = useState(null);
-
-    const game = useContext(GameTraitsCtx)
 
     useEffect(() => {
         attempt(async () => {

--- a/WebRandomizer/ClientApp/src/components/Layout.jsx
+++ b/WebRandomizer/ClientApp/src/components/Layout.jsx
@@ -12,13 +12,13 @@ const GlobalStyle = createGlobalStyle`
   }
 `;
 
-export default function Layout(props) {
+export default function Layout({ children }) {
     return (
         <>
             <GlobalStyle />
-            <NavMenu gameId={props.gameId} />
+            <NavMenu />
             <Container className="mb-5">
-                {props.children}
+                {children}
             </Container>
         </>
     );

--- a/WebRandomizer/ClientApp/src/components/Multiworld.jsx
+++ b/WebRandomizer/ClientApp/src/components/Multiworld.jsx
@@ -1,10 +1,14 @@
-﻿import React, { useState, useEffect, useRef } from 'react';
+﻿import React, { useState, useEffect, useRef, useContext } from 'react';
 import { Row, Col } from 'reactstrap';
+import MessageCard from './util/MessageCard'
 import Seed from './Seed';
 import Patch from './Patch';
 import Connection from './Connection';
 import Game from './Game';
 import Spoiler from './Spoiler';
+
+import { GameTraitsCtx } from '../game/traits';
+import { gameServiceHost, adjustHostname } from '../site';
 
 import Network from '../network';
 
@@ -16,9 +20,11 @@ export default function Multiworld(props) {
     const [sessionStatus, setSessionStatus] = useState('');
     const [gameStatus, setGameStatus] = useState('');
 
+    const game = useContext(GameTraitsCtx);
+
     useEffect(() => {
         const sessionGuid = decode(props.match.params.session_id).replace(/-/g, "");
-        network.current = new Network(sessionGuid, getGameServiceUri(), {
+        network.current = new Network(sessionGuid, gameServiceHost(document.baseURI), {
             setState: setState,
             setSessionStatus: setSessionStatus,
             setGameStatus: setGameStatus
@@ -29,11 +35,6 @@ export default function Multiworld(props) {
             return () => network.current.stop();
         }
     }, []); /* eslint-disable-line react-hooks/exhaustive-deps */
-
-    function getGameServiceUri() {
-        const baseHostname = new URL(document.baseURI).hostname;
-        return baseHostname.includes('localhost') ? 'localhost:5101' : `svc.${baseHostname}`;        
-    }
 
     function onRegisterPlayer(sessionGuid, clientGuid) {
         localStorage.setItem(sessionGuid, clientGuid);
@@ -52,50 +53,56 @@ export default function Multiworld(props) {
     if (state === null) return null;
 
     const { session, clientData, device } = state;
-
-    return (<>
-        {session.guid && (
-            <Row className="mb-3">
-                <Col>
-                    <Seed session={session} sessionStatus={sessionStatus}
-                        onRegisterPlayer={onRegisterPlayer}
-                    />
-                </Col>
-            </Row>
-        )}
-        {clientData !== null && (
-            <Row className="mb-3">
-                <Col>
-                    <Patch
-                        seed={session.data.seed}
-                        world={session.data.seed.worlds.find(world => world.worldId === clientData.worldId)}
-                    />
-                </Col>
-            </Row>
-        )}
-        {clientData !== null && (
-            <Row className="mb-3">
-                <Col>
-                    <Connection clientData={clientData} device={device}
-                        onConnect={onConnect}
-                        onDeviceSelect={onDeviceSelect}
-                    />
-                </Col>
-            </Row>
-        )}
-        {device.state === 1 && (
-            <Row className="mb-3">
-                <Col>
-                    <Game gameStatus={gameStatus} network={network.current} />
-                </Col>
-            </Row>
-        )}
-        {session.data !== null && (
-            <Row className="mb-3">
-                <Col>
-                    <Spoiler seedData={session.data.seed} />
-                </Col>
-            </Row>
-        )}
-    </>);
+    const gameMismatch = session.data && session.data.seed.gameId !== game.id;
+    return !gameMismatch ? (
+        <>
+            {session.guid && (
+                <Row className="mb-3">
+                    <Col>
+                        <Seed session={session} sessionStatus={sessionStatus}
+                            onRegisterPlayer={onRegisterPlayer}
+                        />
+                    </Col>
+                </Row>
+            )}
+            {clientData !== null && (
+                <Row className="mb-3">
+                    <Col>
+                        <Patch
+                            seed={session.data.seed}
+                            world={session.data.seed.worlds.find(world => world.worldId === clientData.worldId)}
+                        />
+                    </Col>
+                </Row>
+            )}
+            {clientData !== null && (
+                <Row className="mb-3">
+                    <Col>
+                        <Connection clientData={clientData} device={device}
+                            onConnect={onConnect}
+                            onDeviceSelect={onDeviceSelect}
+                        />
+                    </Col>
+                </Row>
+            )}
+            {device.state === 1 && (
+                <Row className="mb-3">
+                    <Col>
+                        <Game gameStatus={gameStatus} network={network.current} />
+                    </Col>
+                </Row>
+            )}
+            {session.data !== null && (
+                <Row className="mb-3">
+                    <Col>
+                        <Spoiler seedData={session.data.seed} />
+                    </Col>
+                </Row>
+            )}
+        </>) :
+        (
+            <MessageCard error={true} title="This is not quite right :O"
+                msg={<a href={adjustHostname(document.location.href, session.data.seed.gameId)}>Go to the correct domain here</a>}
+            />
+        );
 }

--- a/WebRandomizer/ClientApp/src/components/NavMenu.jsx
+++ b/WebRandomizer/ClientApp/src/components/NavMenu.jsx
@@ -30,7 +30,7 @@ export default function NavMenu() {
                     <Collapse className="d-sm-inline-flex flex-sm-row-reverse" navbar isOpen={showMenu}>
                         <Nav className="flex-grow" navbar>
                             <NavItem>
-                                <NavLink {...linkProps} to={`/configure/${game.id}`}>Generate randomized game</NavLink>
+                                <NavLink {...linkProps} to={"/configure"}>Generate randomized game</NavLink>
                             </NavItem>
                             <UncontrolledDropdown nav inNavbar>
                                 <DropdownToggle className="text-dark" nav caret>Help</DropdownToggle>

--- a/WebRandomizer/ClientApp/src/components/NavMenu.jsx
+++ b/WebRandomizer/ClientApp/src/components/NavMenu.jsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { Container, Navbar, NavbarBrand, NavbarToggler, Collapse, Nav, NavItem, NavLink } from 'reactstrap';
 import { UncontrolledDropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
+
+import { GameTraitsCtx } from '../game/traits';
 
 const StyledNavbar = styled(Navbar)`
   box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
@@ -14,10 +16,9 @@ const StyledNavbarBrand = styled(NavbarBrand)`
   word-break: break-all;
 `;
 
-export default function NavMenu(props) {
-    const { gameId } = props;
-
+export default function NavMenu() {
     const [showMenu, setShowMenu] = useState(false);
+    const game = useContext(GameTraitsCtx);
 
     const linkProps = { tag: Link, className: 'text-dark' };
     return (
@@ -29,14 +30,14 @@ export default function NavMenu(props) {
                     <Collapse className="d-sm-inline-flex flex-sm-row-reverse" navbar isOpen={showMenu}>
                         <Nav className="flex-grow" navbar>
                             <NavItem>
-                                <NavLink {...linkProps} to={`/configure/${gameId}`}>Generate randomized game</NavLink>
+                                <NavLink {...linkProps} to={`/configure/${game.id}`}>Generate randomized game</NavLink>
                             </NavItem>
                             <UncontrolledDropdown nav inNavbar>
                                 <DropdownToggle className="text-dark" nav caret>Help</DropdownToggle>
                                 <DropdownMenu>
                                     <DropdownItem><NavLink {...linkProps} to="/information">Information</NavLink></DropdownItem>
                                     <DropdownItem><NavLink {...linkProps} to="/mwinstructions">Multiworld instructions</NavLink></DropdownItem>
-                                    {gameId === "smz3" && (
+                                    {game.id === 'smz3' && (
                                         <DropdownItem><NavLink {...linkProps} to="/logic">Logic Log</NavLink></DropdownItem>
                                     )}
                                     <DropdownItem><NavLink {...linkProps} to="/resources">Resources</NavLink></DropdownItem>

--- a/WebRandomizer/ClientApp/src/components/Patch.jsx
+++ b/WebRandomizer/ClientApp/src/components/Patch.jsx
@@ -1,4 +1,4 @@
-﻿import React, { useState, useEffect } from 'react';
+﻿import React, { useState, useEffect, useContext } from 'react';
 import styled from 'styled-components';
 import { Form, Row, Col, Card, CardBody } from 'reactstrap';
 import { Label, Button, Input, InputGroupAddon, InputGroupText } from 'reactstrap';
@@ -8,13 +8,14 @@ import DropdownSelect from './util/DropdownSelect';
 import DownloadInfoTooltip from './util/DownloadInfoTooltip';
 import Upload from './Upload';
 
+import { GameTraitsCtx } from '../game/traits';
+
 import { prepareRom } from '../file/rom';
 
 import localForage from 'localforage';
 import { saveAs } from 'file-saver';
 import { encode } from 'slugid';
 
-import includes from 'lodash/includes';
 import compact from 'lodash/compact';
 import join from 'lodash/join';
 import set from 'lodash/set';
@@ -68,18 +69,14 @@ export default function Patch(props) {
     const [z3HeartBeep, setZ3HeartBeep] = useState('half');
     const [smEnergyBeep, setSMEnergyBeep] = useState(true);
 
+    const game = useContext(GameTraitsCtx);
+
     const sprites = {
         z3: [{ title: 'Link' }, ...inventory.z3],
         sm: [{ title: 'Samus' }, ...inventory.sm]
     };
 
     const { seed, world } = props;
-    const { gameId } = seed;
-    const game = {
-        smz3: gameId === 'smz3',
-        z3: gameId === 'smz3',
-        sm: includes(['smz3', 'sm'], gameId)
-    };
 
     useEffect(() => {
         attempt(async () => {
@@ -109,7 +106,7 @@ export default function Patch(props) {
         try {
             if (world !== null) {
                 const settings = { z3Sprite, smSprite, smSpinjumps, z3HeartColor, z3HeartBeep, smEnergyBeep };
-                const patchedData = await prepareRom(world.patch, settings, baseIps[gameId], game);
+                const patchedData = await prepareRom(world.patch, settings, baseIps[game.id], game);
                 saveAs(new Blob([patchedData]), constructFileName());
             }
         } catch (error) {
@@ -118,7 +115,7 @@ export default function Patch(props) {
     }
 
     function constructFileName() {
-        const { gameVersion, guid, seedNumber, mode } = seed;
+        const { gameId, gameVersion, guid, seedNumber, mode } = seed;
         const settings = world.settings && JSON.parse(world.settings);
 
         /* compact works as long as seedNumber is string, since 0 is a valid number */
@@ -188,11 +185,11 @@ export default function Patch(props) {
         localStorage.setItem('persist', JSON.stringify(values));
     }
 
-    const component = patchState === 'upload' ? <Upload game={game} onUpload={onUploadRoms} /> : (
+    const component = patchState === 'upload' ? <Upload onUpload={onUploadRoms} /> : (
         <Form onSubmit={(e) => e.preventDefault()}>
             <Row className="mb-3">
                 <Col md={game.smz3 ? 8 : 6}>
-                    <SpriteSettings game={game} sprites={sprites} settings={{ z3Sprite, smSprite, smSpinjumps }}
+                    <SpriteSettings sprites={sprites} settings={{ z3Sprite, smSprite, smSpinjumps }}
                         onZ3SpriteChange={onZ3SpriteChange}
                         onSMSpriteChange={onSMSpriteChange}
                         onSpinjumpToggle={onSpinjumpToggle}
@@ -236,7 +233,7 @@ export default function Patch(props) {
             <Row>
                 <Col className="d-flex align-items-center" md="6">
                     <Button color="primary" onClick={onDownloadRom}>Download ROM</Button>
-                    <DownloadInfoTooltip className="ml-2" gameId={gameId} />
+                    <DownloadInfoTooltip className="ml-2" gameId={game.id} />
                 </Col>
             </Row>
         </Form>
@@ -252,8 +249,9 @@ export default function Patch(props) {
 }
 
 function SpriteSettings(props) {
-    const { game, sprites, settings } = props;
+    const { sprites, settings } = props;
     const { z3Sprite, smSprite, smSpinjumps } = settings;
+    const game = useContext(GameTraitsCtx);
 
     let value;
     return (

--- a/WebRandomizer/ClientApp/src/components/Seed.jsx
+++ b/WebRandomizer/ClientApp/src/components/Seed.jsx
@@ -7,7 +7,7 @@ export default function Seed(props) {
     const { session, sessionStatus } = props;
     const { seed, clients } = session.data || {};
 
-    const onRegisterPlayer = props.onRegisterPlayer;
+    const { onRegisterPlayer } = props;
 
     return (
         <Card>
@@ -27,15 +27,16 @@ export default function Seed(props) {
                 <Row>
                     {session.state > 0 && seed.worlds.map((world, i) => {
                         const client = clients.find(client => client.guid === world.guid);
-                        return (<Col key={`player-${i}`} md="3">
-                            <h5>{world.player}</h5>
-                            {client == null ?
-                                <Button color="primary" onClick={() => onRegisterPlayer(session.guid, world.guid)}>Register as this player</Button> :
-                                <Button disabled color={client.state < 5 ? 'secondary' : client.state === 5 ? 'warning' : 'success'}>
-                                    {client.state < 5 ? 'Registered' : client.state === 5 ? 'Connected' : 'Ready'}
-                                </Button>
-                            }
-                        </Col>
+                        return (
+                            <Col key={`player-${i}`} md="3">
+                                <h5>{world.player}</h5>
+                                {client == null ?
+                                    <Button color="primary" onClick={() => onRegisterPlayer(session.guid, world.guid)}>Register as this player</Button> :
+                                    <Button disabled color={client.state < 5 ? 'secondary' : client.state === 5 ? 'warning' : 'success'}>
+                                        {client.state < 5 ? 'Registered' : client.state === 5 ? 'Connected' : 'Ready'}
+                                    </Button>
+                                }
+                            </Col>
                         );
                     })}
                 </Row>

--- a/WebRandomizer/ClientApp/src/components/SmHome.jsx
+++ b/WebRandomizer/ClientApp/src/components/SmHome.jsx
@@ -5,7 +5,7 @@ const homeMarkdown =
 `
 ## Super Metroid Randomizer
 
-To generate a Super Metroid seed, go to the [Generate game](/configure/sm) page.
+To generate a Super Metroid seed, go to the [Generate game](/configure) page.
 
 `;
 

--- a/WebRandomizer/ClientApp/src/components/Smz3Home.jsx
+++ b/WebRandomizer/ClientApp/src/components/Smz3Home.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Jumbotron, Container, Row, Col, Button } from 'reactstrap';
 
-export default function Home() {
+export default function Smz3Home() {
     return (
         <>
             <Jumbotron>

--- a/WebRandomizer/ClientApp/src/components/Smz3Home.jsx
+++ b/WebRandomizer/ClientApp/src/components/Smz3Home.jsx
@@ -18,7 +18,7 @@ export default function Smz3Home() {
                     <Col md="4">
                         <h2>Get started</h2>
                         <p>Follow the link below to get to the game generation page and head directly into the action.</p>
-                        <span className="align-bottom"><a href="/configure/smz3"><Button color="primary">Generate game</Button></a></span>
+                        <span className="align-bottom"><a href="/configure"><Button color="primary">Generate game</Button></a></span>
                     </Col>
                     <Col md="4">
                         <h2>Get help</h2>

--- a/WebRandomizer/ClientApp/src/components/Upload.jsx
+++ b/WebRandomizer/ClientApp/src/components/Upload.jsx
@@ -1,7 +1,9 @@
-﻿import React, { useState, useRef } from 'react';
+﻿import React, { useState, useRef, useContext } from 'react';
 import { Form, Row, Col, Button } from 'reactstrap';
 import { readAsArrayBuffer } from '../file/util';
 import { h32 } from 'xxhashjs';
+
+import { GameTraitsCtx } from '../game/traits';
 
 import localForage from 'localforage';
 
@@ -19,8 +21,7 @@ export default function Upload(props) {
     const [canUpload, setCanUpload] = useState(false);
     const fileInputSM = useRef(null);
     const fileInputZ3 = useRef(null);
-
-    const { game } = props;
+    const game = useContext(GameTraitsCtx);
 
     async function onSubmitRom() {
         const smFile = fileInputSM.current.files[0];

--- a/WebRandomizer/ClientApp/src/components/util/MessageCard.jsx
+++ b/WebRandomizer/ClientApp/src/components/util/MessageCard.jsx
@@ -1,0 +1,20 @@
+﻿import React from 'react';
+import { Card, CardHeader, CardBody } from 'reactstrap';
+import classNames from 'classnames';
+
+export default function MessageCard({ error, title, msg }) {
+    return (
+        <Card>
+            <CardHeader className={classNames({
+                    'bg-danger': error,
+                    'bg-primary': !error
+                }, 'text-white'
+            )}>
+                {title}
+            </CardHeader>
+            <CardBody>
+                {msg}
+            </CardBody>
+        </Card>
+    );
+}

--- a/WebRandomizer/ClientApp/src/file/rdc.js
+++ b/WebRandomizer/ClientApp/src/file/rdc.js
@@ -129,16 +129,14 @@ function parse_block(block, manifest) {
     return content;
 }
 
-function apply_block(rom, mode, content, manifest) {
+function apply_block(rom, mapping, content, manifest) {
     let index = -1;
     for (const [addrs, length, entries = 1, offset = 0] of manifest) {
-        const _addrs = isPlainObject(addrs)
-            ? addrs[mode.exhirom || mode.lorom]
-            : addrs;
+        const _addrs = isPlainObject(addrs) ? addrs[mapping] : addrs;
         const entry = content[index += 1];
         for (const addr of _addrs) {
             for (let i = 0; i < entries; i += 1) {
-                const dest = snes_to_pc(mode, addr + (isArray(offset) ? offset[i] : offset * i));
+                const dest = snes_to_pc(mapping, addr + (isArray(offset) ? offset[i] : offset * i));
                 const src = length * i;
                 rom.set(entry.slice(src, src + length), dest);
             }

--- a/WebRandomizer/ClientApp/src/file/util.js
+++ b/WebRandomizer/ClientApp/src/file/util.js
@@ -14,13 +14,13 @@ export async function readAsArrayBuffer(blob) {
     });
 }
 
-export function snes_to_pc(mode = {}, addr) {
-    if (mode.exhirom) {
+export function snes_to_pc(mapping, addr) {
+    if (mapping === 'exhirom') {
         const ex = addr < 0x800000 ? 0x400000 : 0;
         const pc = addr & 0x3FFFFF;
         return ex | pc;
     }
-    if (mode.lorom) {
+    if (mapping === 'lorom') {
         return ((addr & 0x7F0000) >>> 1) | (addr & 0x7FFF);
     }
     throw new Error('No known addressing mode supplied');

--- a/WebRandomizer/ClientApp/src/game/traits.js
+++ b/WebRandomizer/ClientApp/src/game/traits.js
@@ -1,0 +1,27 @@
+﻿import React from 'react';
+
+import defaultTo from 'lodash/defaultTo';
+
+const traits = {
+    smz3: {
+        id: 'smz3',
+        smz3: true,
+        z3: true,
+        sm: true,
+        mapping: 'exhirom'
+    },
+    sm: {
+        id: 'sm',
+        sm: true,
+        mapping: 'lorom'
+    },
+    none: {
+        id: 'none'
+    }
+};
+
+export function resolveGameTraits(gameId) {
+    return defaultTo(traits[gameId], traits.none);
+}
+
+export const GameTraitsCtx = React.createContext(traits.none);

--- a/WebRandomizer/ClientApp/src/network/index.js
+++ b/WebRandomizer/ClientApp/src/network/index.js
@@ -4,7 +4,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 export default class Network {
 
-    constructor(sessionGuid, gameServiceUri, react) {
+    constructor(sessionGuid, gameServiceHost, react) {
         this.connection = null;
         this.socket = null;
         this.inPtr = -1;
@@ -14,7 +14,7 @@ export default class Network {
         this.eventLoopTimer = 0;
         this.MessageBaseAddress = null;
         this.ItemsBaseAddress = null;
-        this.GameServiceUri = gameServiceUri;
+        this.GameServiceHost = gameServiceHost;
 
         this.session = {
             guid: sessionGuid,
@@ -54,7 +54,7 @@ export default class Network {
 
     init() {
         this.connection = new HubConnectionBuilder()
-            .withUrl(`https://${this.GameServiceUri}/multiworldHub`)
+            .withUrl(`https://${this.GameServiceHost}/multiworldHub`)
             .build();
 
         this.connection.onclose(() => {
@@ -86,7 +86,7 @@ export default class Network {
         this.react.setSessionStatus('Initializing session...');
 
         try {
-            const response = await fetch(`https://${this.GameServiceUri}/api/multiworld/session/${this.session.guid}`);
+            const response = await fetch(`https://${this.GameServiceHost}/api/multiworld/session/${this.session.guid}`);
             if (response.status !== 200) {
                 this.session.state = 0;
                 this.updateState();

--- a/WebRandomizer/ClientApp/src/resources/markdown/sminformation.md
+++ b/WebRandomizer/ClientApp/src/resources/markdown/sminformation.md
@@ -28,7 +28,7 @@
 
 ## Quick guide to getting started
 
-To create a new randomized game, head over to the [Generate Randomizer Game](/configure/sm) page.
+To create a new randomized game, head over to the [Generate Randomizer Game](/configure) page.
 
 1. Select the options you want to use for the game, and then press **Generate
    Game** to generate a new game.

--- a/WebRandomizer/ClientApp/src/resources/markdown/smz3information.md
+++ b/WebRandomizer/ClientApp/src/resources/markdown/smz3information.md
@@ -37,7 +37,7 @@ For more information and useful links to helpful resources, visit the [Resources
 
 ## Quick guide to getting started
 
-To create a new randomized game, head over to the [Generate Randomizer Game](/configure/smz3) page.
+To create a new randomized game, head over to the [Generate Randomizer Game](/configure) page.
 
 1. Select the options you want to use for the game, and then press **Generate
    Game** to generate a new game.

--- a/WebRandomizer/ClientApp/src/site.js
+++ b/WebRandomizer/ClientApp/src/site.js
@@ -1,0 +1,28 @@
+const domainPattern = /^([^.]*).?/;
+/* Does not include smz3 because in that case the root domain is used directly */
+const domains = ['sm'];
+const domainBy = { sm: 'sm.', smz3: '' };
+
+export function resolveGameId(href) {
+    const url = new URL(href);
+    const hostname = url.hostname;
+    const [,id] = hostname.match(domainPattern);
+    return domains.includes(id) ? id : 'smz3';
+}
+
+export function adjustHostname(href, id) {
+    const url = new URL(href);
+    const hostname = url.hostname;
+    url.hostname = `${domainBy[id]}${hostname.replace(domainPattern, removeGameDomain)}`;
+    return url.href;
+}
+
+function removeGameDomain(match, id) {
+    return domains.includes(id) ? '' : match;
+}
+
+export function gameServiceHost(href) {
+    const url = new URL(href);
+    const hostname = url.hostname;
+    return hostname.includes('localhost') ? 'localhost:5101' : `svc.${hostname}`;
+}


### PR DESCRIPTION
Patch had code to resolve the specific traits for the game being served by the site. This information is needed at other places in the implementation so we lift this out to the App component. From there it is passed through a react context since it's used so ubiquitously.

Since the Configure, Permalink, and Multiworld components should only service a certain game while on the corresponding sub domain we add a check for this. If there is a mismatch we offer a link with the same path, but correct hostname. The supporting functions are hosted in a new ./site module.

Together with the game traits we simplify the snes addressing such that we can skip the booleans and only use the address mapping names (exhirom and lorom).

Minor changes:
- The default game is smz3, so the trailing branch (else clause, last value in trinary operator chain) should be smz3.
- The `gameServiceUri` function (renamed `gameServiceHost`) fits with the new ./site module so we move it there.
- A `MessageCard` component is abstracted to make it easier to fit into code with multiple branches.
- In the case that `JSON.parse` throw SyntaxError, we catch and return null.