### PR TITLE
Add race and keysanity bits to the seed data field

### DIFF
--- a/Randomizer.SMZ3/Patch.cs
+++ b/Randomizer.SMZ3/Patch.cs
@@ -544,6 +544,8 @@ namespace Randomizer.SMZ3 {
 
         void WriteSeedData() {
             var configField =
+                ((myWorld.Config.Race ? 1 : 0) << 15) |
+                ((myWorld.Config.Keysanity ? 1 : 0) << 13) |
                 ((myWorld.Config.GameMode == GameMode.Multiworld ? 1 : 0) << 12) |
                 ((int)myWorld.Config.Z3Logic << 10) |
                 ((int)myWorld.Config.SMLogic << 8) |


### PR DESCRIPTION
- bit 15: Race rom?
- bit 14-13: Keysanity? Currently only bit 13 matters, but we reserve two bits in case we want more fine grained settings.