### PR TITLE
Update WreckedShip.cs

### DIFF
--- a/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
@@ -12,7 +12,9 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid {
 
         public WreckedShip(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
-                new Location(this, 128, 0x8FC265, LocationType.Visible, "Missile (Wrecked Ship middle)"),
+                new Location(this, 128, 0x8FC265, LocationType.Visible, "Missile (Wrecked Ship middle)", Logic switch {
+                    _ => new Requirement(items => items.CanPassBombPassages())
+                }),
                 new Location(this, 129, 0x8FC2E9, LocationType.Chozo, "Reserve Tank, Wrecked Ship", Logic switch {
                     Normal => items => CanUnlockShip(items) && items.SpeedBooster && items.CanUsePowerBombs() &&
                         (items.Grapple || items.SpaceJump || items.Varia && items.HasEnergyReserves(2) || items.HasEnergyReserves(3)),
@@ -45,7 +47,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid {
         }
 
         bool CanUnlockShip(Progression items) {
-            return !Config.Keysanity || items.PhantoonKey;
+            return items.CanPassBombPassages() && (!Config.Keysanity || items.PhantoonKey);
         }
 
         public override bool CanEnter(Progression items) {


### PR DESCRIPTION
Previous change only considered getting through the doors of WS, not collecting items once inside, and thus put WS items in logic without the ability to get through the bomb passages to spooky missiles or Phantoon. This is a non-issue with assured early bombs, and a fringe issue in any case, but still needed fixing.