### PR TITLE
Add seed options to the CLI (refined)

### DIFF
--- a/Randomizer.CLI/FileData/Rom.cs
+++ b/Randomizer.CLI/FileData/Rom.cs
@@ -34,6 +34,12 @@ namespace Randomizer.CLI.FileData {
             return combined;
         }
 
+        public static byte[] ExpandRom(Stream rom, int size) {
+            var expanded = new byte[size];
+            rom.Read(expanded, 0, size);
+            return expanded;
+        }
+
         public static void ApplyIps(byte[] rom, Stream ips) {
             const int header = 5;
             const int footer = 3;

--- a/Randomizer.CLI/Verbs/GenSeed.cs
+++ b/Randomizer.CLI/Verbs/GenSeed.cs
@@ -86,7 +86,9 @@ namespace Randomizer.CLI.Verbs {
         public SMSeedOptions() {
             smRom = new Lazy<byte[]>(() => {
                 using var ips = OpenReadInnerStream(Ips.First());
-                var rom = File.ReadAllBytes(smFile);
+                using var sm = File.OpenRead(smFile);
+                /* Account for custom sprites */
+                var rom = FileData.Rom.ExpandRom(sm, 0x400000);
                 FileData.Rom.ApplyIps(rom, ips);
                 return rom;
             });


### PR DESCRIPTION
Refinement of PR #114 (with authorship preserved).
- Enables correct generation of SM rando rom files after the introduction of the Samus custom sprite implementation by remembering to extend the rom to 4 MB.
- Moves the SMZ3 seed options to the verb sub class so that they are not available for the SM verb.
- Provides all lower case values for the KeyShuffle api option. Option values are case insensitive, but let's use lower case for consistency.
- Make separate boolean Sword and Morph CLI parameters instead of string parameters. This makes it consistent with the existing Normal/Hard logic parameters.
- Name the Sword and Morph parameters by their corresponding api value names. As a dev tool, CLI should not hide these implementation details.
- Adds the Placement seed option to the SM verb sub class.
- Replicated the new file naming schema, using a similar code structure to that used by the corresponding Javascript function, and also reused this for naming the playthrough and patch json files.
- Dropped all ALttP asm sub module updates as none of them pointed to a commit on the master branch. The workflow that has been used is to await acceptance of PRs on the asm repos, and only then send a PR on this repo (or finalize a draft PR) which would include both a sub module update as well as an update to the {zsm|sm}.ips.gz file.

Closes #114 