### PR TITLE
Add race bit to the SM seed data field

### DIFF
--- a/Randomizer.SuperMetroid/Patch.cs
+++ b/Randomizer.SuperMetroid/Patch.cs
@@ -302,6 +302,7 @@ namespace Randomizer.SuperMetroid {
 
         void WriteSeedData() {
             var configField =
+                ((myWorld.Config.Race ? 1 : 0) << 15) |
                 ((myWorld.Config.GameMode == GameMode.Multiworld ? 1 : 0) << 12) |
                 /* Gap of 2 bits, taken by Z3 logic in combo */
                 ((int)myWorld.Config.Logic << 8) |


### PR DESCRIPTION
We had only set this bit for SMZ3 seed patches, but naturally it should also be set in SM seed patches.

- bit 15: Race rom?