### PR TITLE
Skip the HC and GT maps in keysanity

### DIFF
--- a/Randomizer.SMZ3/Item.cs
+++ b/Randomizer.SMZ3/Item.cs
@@ -460,7 +460,7 @@ namespace Randomizer.SMZ3 {
             itemPool.AddRange(Copies(4,  () => new Item(BombUpgrade5)));
             itemPool.AddRange(Copies(2,  () => new Item(OneRupee)));
             itemPool.AddRange(Copies(4,  () => new Item(FiveRupees)));
-            itemPool.AddRange(Copies(world.Config.Keysanity ? 23 : 28, () => new Item(TwentyRupees)));
+            itemPool.AddRange(Copies(world.Config.Keysanity ? 25 : 28, () => new Item(TwentyRupees)));
             itemPool.AddRange(Copies(7,  () => new Item(FiftyRupees)));
             itemPool.AddRange(Copies(5,  () => new Item(ThreeHundredRupees)));
 
@@ -506,7 +506,6 @@ namespace Randomizer.SMZ3 {
             itemPool.AddRange(Copies(4, () => new Item(KeyGT)));
 
             itemPool.AddRange(new[] {
-                new Item(MapHC),
                 new Item(MapEP),
                 new Item(MapDP),
                 new Item(MapTH),
@@ -517,10 +516,11 @@ namespace Randomizer.SMZ3 {
                 new Item(MapIP),
                 new Item(MapMM),
                 new Item(MapTR),
-                new Item(MapGT)
             });
             if (!world.Config.Keysanity) {
                 itemPool.AddRange(new[] {
+                    new Item(MapHC),
+                    new Item(MapGT),
                     new Item(CompassEP),
                     new Item(CompassDP),
                     new Item(CompassTH),


### PR DESCRIPTION
These two maps have no functionality (compared to the other ten which enable viewing the dungeon prize on the world map). Their slots would be better served by restoring two more Red Rupees from the vanilla item pool.