### PR TITLE
Added rom checksum fix

### DIFF
--- a/WebRandomizer/ClientApp/src/file/rom.js
+++ b/WebRandomizer/ClientApp/src/file/rom.js
@@ -46,6 +46,8 @@ export async function prepareRom(world_patch, settings, baseIps, game) {
 
     applySeed(rom, world_patch);
 
+    fixupChecksum(rom, game);
+    
     return rom;
 }
 
@@ -196,4 +198,25 @@ function applySeed(rom, patch) {
         rom.set(patch.slice(offset, offset + length), dest);
         offset += length;
     }
+}
+
+function applyChecksum(rom, mapping, sum) {
+  var offset = snes_to_pc(mapping, 0xFFDC);
+  var inv = ~sum;
+  rom[offset + 0] = 0xFF & inv;
+  rom[offset + 1] = 0xFF & (inv >> 8);
+  rom[offset + 2] = 0xFF & sum;
+  rom[offset + 3] = 0xFF & (sum >> 8);
+}
+
+function fixupChecksum(rom, game) {
+  //Refer to https://sneslab.net/wiki/SNES_ROM_Header for more information.
+  var firstChunkSize = game.smz3 ? 0x400000 : 0x200000;
+  const { mapping } = game;
+
+  applyChecksum(rom, mapping, 0); //ensures sane sum/inv before counting
+  var sum = 0, i = 0;
+  while(i < firstChunkSize) { sum +=     rom[i++]; }
+  while(i < rom.length)     { sum += 2 * rom[i++]; }
+  applyChecksum(rom, mapping, sum);
 }


### PR DESCRIPTION
Added functions to WebRandomizer/ClientApp/src/file/rom.js which calculate and apply a corrected checksum for the rom data. Added an invocation at the end of prepareRom().

This should work for SM and SMZ3, but I've only just got the SMZ3 web gen working and still don't know how to launch the SM page, so I was not able to test it for SM.

Note that the fixupChecksum() function assumes that the ROM will be either SMZ3(6MB) or SM(3MB) and won't calculate the correct sum for other ROM sizes. If the size of either ROM is changed then the algorithm used should be updated accordingly (see link in code comment), but won't cause any issue other than incorrect sums if it's ignored.