### PR TITLE
Fix Aqueduct access rules

### DIFF
--- a/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
@@ -87,7 +87,12 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
         }
 
         bool CanReachAqueduct(Progression items) {
-            return items.CardMaridiaL1 || items.CardMaridiaL2 && items.CanAccessMaridiaPortal(World);
+            return Logic switch { 
+               Normal => items.CardMaridiaL1 && (items.CanFly() || items.SpeedBooster || items.Grapple) 
+                        || items.CardMaridiaL2 && items.CanAccessMaridiaPortal(World),
+               _ => items.CardMaridiaL1 && (items.Gravity || items.HiJump && (items.Ice || items.CanSpringBallJump()) && items.Grapple) 
+                        || items.CardMaridiaL2 && items.CanAccessMaridiaPortal(World)
+            };
         }
 
         bool CanDefeatDraygon(Progression items) {


### PR DESCRIPTION
Fix a bug with the sandpit items where the portal satisfies CanEnter and having the MaridiaL1 key satisfies CanReachAqueduct, without checking if you can climb Main Street and Mt. Everest.