### PR TITLE
Fix Forgotten Highway access to WS on normal

### DIFF
--- a/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
@@ -62,8 +62,8 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid {
                         /* Through Maridia -> Forgotten Highway */
                         items.CanUsePowerBombs() && items.Gravity ||
                         /* From Maridia portal -> Forgotten Highway */
-                        items.CanAccessMaridiaPortal(World) && items.Gravity && items.CardMaridiaL2 && (
-                            items.CanDestroyBombWalls() ||
+                        items.CanAccessMaridiaPortal(World) && items.Gravity && (
+                            items.CanDestroyBombWalls() && items.CardMaridiaL2 ||
                             World.Locations.Get("Space Jump").Available(items)
                         )
                     ),


### PR DESCRIPTION
When going to WS via Forgotten Highway after killing Draygon and going through Cacattack Alley, the Maradia L2 key is not needed.  On hard mode, this is correctly not required.  This fixes the normal logic to match that, requiring the Maridia L2 key only when going back through the sand pits and up the toilet.