### PR TITLE
Fix moat logic

### DIFF
--- a/Randomizer.SuperMetroid/Regions/Crateria/East.cs
+++ b/Randomizer.SuperMetroid/Regions/Crateria/East.cs
@@ -14,19 +14,21 @@ namespace Randomizer.SuperMetroid.Regions.Crateria {
         public East(World world, Logic logic) : base(world, logic) {
             Locations = new List<Location> {
                 new Location(this, 1, "Missile (outside Wrecked Ship bottom)", Visible, Minor, 0x781E8, Logic switch {
-                    Casual => items => items.Has(SpaceJump) || items.Has(SpeedBooster) || items.Has(Grapple),
+                    Casual => items => items.Has(SpaceJump) || items.Has(SpeedBooster) || items.Has(Grapple) ||
+                                        items.Has(Gravity) && (items.CanFly() || items.Has(HiJump)),
                     _ => new Requirement(items => true)
                 }),
                 new Location(this, 2, "Missile (outside Wrecked Ship top)", Hidden, Minor, 0x781EE, Logic switch {
-                    Casual => items => items.Has(Super) && items.CanPassBombPassages() && (items.Has(SpaceJump) || items.Has(SpeedBooster) || items.Has(Grapple)),
+                    Casual => items => items.Has(Super) && items.CanPassBombPassages() && (items.Has(SpaceJump) || items.Has(SpeedBooster) || items.Has(Grapple) ||
+                                       items.Has(Gravity) && (items.CanFly() || items.Has(HiJump))),
                     _ => new Requirement(items => items.Has(Super) && items.CanPassBombPassages())
                 }),
                 new Location(this, 3, "Missile (outside Wrecked Ship middle)", Visible, Minor, 0x781F4, Logic switch {
-                    Casual => items => items.Has(Super) && items.CanPassBombPassages() && (items.Has(SpaceJump) || items.Has(SpeedBooster) || items.Has(Grapple)),
+                    Casual => items => items.Has(Super) && items.CanPassBombPassages() && (items.Has(SpaceJump) || items.Has(SpeedBooster) || items.Has(Grapple) ||
+                                        items.Has(Gravity) && (items.CanFly() || items.Has(HiJump))),
                     _ => new Requirement(items => items.Has(Super) && items.CanPassBombPassages())
                 }),
                 new Location(this, 4, "Missile (Crateria moat)", Visible, Minor, 0x78248, Logic switch {
-                    Casual => items => items.Has(SpaceJump) || items.Has(SpeedBooster) || items.Has(Grapple),
                     _ => new Requirement(items => true)
                 }),
             };


### PR DESCRIPTION
Remove grapple/speed/space requirement from moat missiles. Add crossing the moat with Grav + IBJ/HJB to the others, to match WS CanEnter.

Still ignoring FH access for now. Also ignoring the superfluous super and bomb passage requirements on the upper items, which are covered by CanEnter.