### PR TITLE
Updating Normal Left Sand Pit Room requirements

### DIFF
--- a/Randomizer.SuperMetroid/Regions/Maridia/Inner.cs
+++ b/Randomizer.SuperMetroid/Regions/Maridia/Inner.cs
@@ -36,11 +36,11 @@ namespace Randomizer.SuperMetroid.Regions.Maridia {
                         (items.Has(HiJump) || items.CanSpringBallJump() || items.CanFly() || items.Has(SpeedBooster)))
                 }),
                 new Location(this, 144, "Missile (left Maridia sand pit room)", Visible, Minor, 0x7C5DD, Logic switch {
-                    Casual => items => items.CanPassBombPassages(),
+                    Casual => items => items.CanUsePowerBombs() || items.CanSpringBallJump(),
                     _ => new Requirement(items => items.Has(HiJump) && (items.Has(SpaceJump) || items.CanSpringBallJump()) || items.Has(Gravity))
                 }),
                 new Location(this, 145, "Reserve Tank, Maridia", Chozo, Major, 0x7C5E3, Logic switch {
-                    Casual => items => items.CanPassBombPassages(),
+                    Casual => items => items.CanUsePowerBombs()|| items.CanSpringBallJump(),
                     _ => new Requirement(items => items.Has(HiJump) && (items.Has(SpaceJump) || items.CanSpringBallJump()) || items.Has(Gravity))
                 }),
                 new Location(this, 146, "Missile (right Maridia sand pit room)", Visible, Minor, 0x7C5EB, Logic switch {


### PR DESCRIPTION
Power bombs cannot get you to the top of the Left Sand Pit room. So these checks either requires morph ball, spring, or VERY fast midair morphballing. The morphballing is clearly intended for Hard Mode so this change should remove the need for this on Normal. Context: I recently had a normal run where my Spring and Bombs were Flipper locked, which turned out to be in Lower Norfair which is Space Jump, and Space Jump was in the Left Sand pit room.