### PR TITLE
Logic unit tests

### DIFF
--- a/Randomizer.SMZ3.Tests/Logic/Case.cs
+++ b/Randomizer.SMZ3.Tests/Logic/Case.cs
@@ -1,0 +1,252 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using static System.Linq.Enumerable;
+using static Randomizer.SMZ3.ItemType;
+
+namespace Randomizer.SMZ3.Tests.Logic {
+
+    public class Case : IEnumerable<Preparation> {
+
+        public class Builder : DynamicObject {
+
+            readonly IList<Preparation> list = new List<Preparation>();
+
+            bool has;
+            string atLocation;
+
+            bool assumed;
+
+            Skip skip = Skip.None;
+            List<InventoryItem> subjects;
+
+            enum Skip {
+                None,
+                Which,
+                Also,
+            }
+
+            public override bool TryGetMember(GetMemberBinder binder, out object result) {
+                result = Add(binder.Name);
+                return true;
+            }
+
+            public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result) {
+                result = Add(binder.Name, count: (int) args[0]);
+                return true;
+            }
+
+            dynamic Add(string type, int count = 1) {
+                if (has) {
+                    list.Add(NewHasItem());
+                } else if (skip == Skip.Which) {
+                    subjects ??= new();
+                    subjects.Add(NewInventoryItem());
+                } else if (skip == Skip.Also) {
+                    foreach (var subject in subjects) {
+                        list.Add(subject);
+                        subject.AlsoSkip = NewInventoryItem();
+                    }
+                    subjects = null;
+                    skip = Skip.None;
+                } else {
+                    list.Add(NewInventoryItem());
+                }
+                has = false;
+                atLocation = null;
+                assumed = false;
+                return this;
+
+                LocationItem NewHasItem() => new() { ItemName = type, At = atLocation };
+                InventoryItem NewInventoryItem() => new() { ItemName = type, Count = count, Assumed = assumed };
+            }
+
+            public dynamic HasAt(string location) {
+                atLocation = location;
+                return Has;
+            }
+
+            public dynamic Has {
+                get {
+                    has = true;
+                    return this;
+                }
+            }
+
+            public dynamic Assume {
+                get {
+                    assumed = true;
+                    return this;
+                }
+            }
+
+            public dynamic IfSkipping {
+                get {
+                    skip = Skip.Which;
+                    return this;
+                }
+            }
+
+            public dynamic AlsoSkip {
+                get {
+                    skip = Skip.Also;
+                    return this;
+                }
+            }
+
+            public override bool TryConvert(ConvertBinder binder, out object result) {
+                if (binder.Type != typeof(Case)) {
+                    result = null;
+                    return false;
+                }
+                result = new Case(list);
+                return true;
+            }
+
+        }
+
+        public static Case WithNothing { get; } = new(Empty<Preparation>());
+
+        readonly IEnumerable<Preparation> preparations;
+
+        Case(IEnumerable<Preparation> preparations) => this.preparations = preparations;
+
+        internal IEnumerable<int> IndicesToSkip
+            => from preparation in preparations.Select((v, i) => (v, i))
+               where preparation.v is not InventoryItem x || x.Assumed == false
+               select preparation.i;
+
+        internal Progression Prepare(World world, string name, int? skip = null) {
+            var pool = new List<Item>();
+            foreach (var preparation in preparations) {
+                preparation.Implement(world, name, pool);
+            }
+            if (skip != null) {
+                preparations.ElementAt((int) skip).Skip(world, name, pool);
+            }
+            return new Progression(pool);
+        }
+
+        public IEnumerator<Preparation> GetEnumerator() => preparations.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    }
+
+    public abstract class Preparation {
+
+        public string ItemName { get; set; }
+
+        internal abstract void Implement(World world, string location, List<Item> pool, bool skipOne = false);
+        internal abstract void Skip(World world, string location, List<Item> pool);
+        public abstract string DescribeSkipped();
+
+    }
+
+    public class LocationItem : Preparation {
+
+        public string At { get; set; }
+
+        internal override void Implement(World world, string location, List<Item> pool, bool skipOne = false) {
+            var type = Enum.Parse<ItemType>(ItemName);
+            world.Locations.Get(At ?? location).Item = new Item(type, world);
+        }
+
+        internal override void Skip(World world, string location, List<Item> pool) {
+            world.Locations.Get(At ?? location).Item = null;
+        }
+
+        public override string DescribeSkipped() {
+            return $"Without a {ItemName} at {(At is null ? "this location" : $"\"{At}\"")}";
+        }
+
+        public override string ToString() {
+            return At is null ? $"Has {ItemName}" : $"Has {ItemName} At \"{At}\"";
+        }
+
+    }
+
+    public class InventoryItem : Preparation {
+
+        public int Count { get; set; } = 1;
+        public bool Assumed { get; set; }
+        public InventoryItem AlsoSkip { get; set; }
+
+        static readonly Regex showCountPattern = new(@"^(Key|ETank)");
+
+        internal override void Implement(World world, string location, List<Item> pool, bool skipOne = false) {
+            var type = ItemType;
+            pool.AddRange(
+                from itemType in Repeat(type, ItemCount.all)
+                select new Item(itemType, world)
+            );
+        }
+
+        internal override void Skip(World world, string location, List<Item> pool) {
+            var type = ItemType;
+            pool.RemoveAll(x => x.Type == type);
+            pool.AddRange(
+                from itemType in Repeat(type, ItemCount.skipOne)
+                select new Item(itemType, world)
+            );
+            if (AlsoSkip != null) {
+                AlsoSkip.SkipAll(pool);
+            }
+        }
+
+        void SkipAll(List<Item> pool) {
+            var type = ItemType;
+            var items = pool.Where(x => x.Type == type).Take(Count).ToList();
+            foreach (var item in items) {
+                pool.Remove(item);
+            }
+        }
+
+        ItemType ItemType => ItemName switch {
+            "Glove" => ProgressiveGlove,
+            "Mitt" => ProgressiveGlove,
+            "Sword" => ProgressiveSword,
+            "MasterSword" => ProgressiveSword,
+            "MirrorShield" => ProgressiveShield,
+            "TwoPowerBombs" => PowerBomb,
+            _ => Enum.Parse<ItemType>(ItemName),
+        };
+
+        (int all, int skipOne) ItemCount => ItemName switch {
+            "Glove" => (1, 0),
+            "Mitt" => (2, 1),
+            "Sword" => (1, 0),
+            "MasterSword" => (2, 1),
+            "MirrorShield" => (3, 0),
+            "TwoPowerBombs" => (2, 1),
+            _ => (Count, Count - 1),
+        };
+
+        public override string DescribeSkipped() {
+            var parts = new[] {
+                ItemName switch {
+                    "Mitt" => "With only Glove",
+                    "MasterSword" => "With only Sword",
+                    "TwoPowerBombs" => "With only one PB pack",
+                    _ when Count > 1 => $"With only {Count - 1} {ItemName}",
+                    _ => $"Without {ItemName}",
+                },
+                AlsoSkip is null ? null : $"and {AlsoSkip.Count} fewer {AlsoSkip.ItemName}",
+            };
+            return string.Join(" ", parts.Where(x => x != null));
+        }
+
+        public override string ToString() {
+            var parts = new[] {
+                Assumed ? "Assumed" : null,
+                ItemName,
+                Count > 1 || showCountPattern.IsMatch(ItemName) ? $"{Count}" : null,
+            };
+            return string.Join(" ", parts.Where(x => x != null));
+        }
+
+    }
+
+}

--- a/Randomizer.SMZ3.Tests/Logic/LogicCases.cs
+++ b/Randomizer.SMZ3.Tests/Logic/LogicCases.cs
@@ -1,0 +1,751 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Randomizer.SMZ3.Tests.Logic {
+    
+    public abstract class LogicCases {
+
+        protected readonly List<Case> CaseWithNothing = new() { Case.WithNothing };
+        protected Case CaseWith(Func<dynamic, Case> func) => func(new Case.Builder());
+
+        public static IEnumerable<Locality> ForRegionsUsing<TLogic>() where TLogic : LogicCases, new()
+            => LocalitiesUsing<TLogic, RegionAttribute>();
+
+        public static IEnumerable<Locality> ForLocationsUsing<TLogic>() where TLogic : LogicCases, new()
+            => LocalitiesUsing<TLogic, LocationAttribute>();
+
+        static IEnumerable<Locality> LocalitiesUsing<TLogic, TLocality>()
+            where TLogic : LogicCases, new()
+            where TLocality : LocalityAttribute
+        {
+            var source = new TLogic();
+            return from property in PropertiesOf<LogicCases>()
+                   from locality in LocalitiesOf(property)
+                   let cases = CasesFrom(source, property)
+                   select new Locality(locality.Name, cases);
+
+            static PropertyInfo[] PropertiesOf<T>()
+                => typeof(T).GetProperties(BindingFlags.NonPublic | BindingFlags.Instance);
+            static IEnumerable<TLocality> LocalitiesOf(PropertyInfo property)
+                => Attribute.GetCustomAttributes(property, typeof(TLocality)).Cast<TLocality>();
+            static List<Case> CasesFrom(TLogic source, PropertyInfo property)
+                => property.GetValue(source) as List<Case>;
+        }
+
+        public record Locality(string Name, IList<Case> Cases);
+
+        #region Locality declarations
+
+        [Region("Crateria West")]
+        protected abstract List<Case> CrateriaWest { get; }
+        [Location("Energy Tank, Terminator")]
+        protected abstract List<Case> EnergyTankTerminator { get; }
+        [Location("Energy Tank, Gauntlet")]
+        protected abstract List<Case> EnergyTankGauntlet { get; }
+        [Location("Missile (Crateria gauntlet right)")]
+        [Location("Missile (Crateria gauntlet left)")]
+        protected abstract List<Case> MissileCrateriaGauntlet { get; }
+
+        [Region("Crateria Central")]
+        protected abstract List<Case> CrateriaCentral { get; }
+        [Location("Power Bomb (Crateria surface)")]
+        protected abstract List<Case> PowerBombCrateriaSurface { get; }
+        [Location("Missile (Crateria middle)")]
+        protected abstract List<Case> MissileCrateriaMiddle { get; }
+        [Location("Missile (Crateria bottom)")]
+        protected abstract List<Case> MissileCrateriaBottom { get; }
+        [Location("Super Missile (Crateria)")]
+        protected abstract List<Case> SuperMissileCrateria { get; }
+        [Location("Bombs")]
+        protected abstract List<Case> Bombs { get; }
+
+        [Region("Crateria East")]
+        protected abstract List<Case> CrateriaEast { get; }
+        [Location("Missile (outside Wrecked Ship bottom)")]
+        protected abstract List<Case> MissileOutsideWreckedShipBottom { get; }
+        [Location("Missile (outside Wrecked Ship top)")]
+        [Location("Missile (outside Wrecked Ship middle)")]
+        protected abstract List<Case> MissilesOutsideWreckedShipTopHalf { get; }
+        [Location("Missile (Crateria moat)")]
+        protected abstract List<Case> MissileCrateriaMoat { get; }
+
+        [Region("Wrecked Ship")]
+        protected abstract List<Case> WreckedShip { get; }
+        [Location("Missile (Wrecked Ship middle)")]
+        protected abstract List<Case> MissileWreckedShipMiddle { get; }
+        [Location("Reserve Tank, Wrecked Ship")]
+        protected abstract List<Case> ReserveTankWreckedShip { get; }
+        [Location("Missile (Gravity Suit)")]
+        protected abstract List<Case> MissileGravitySuit { get; }
+        [Location("Missile (Wrecked Ship top)")]
+        protected abstract List<Case> MissileWreckedShipTop { get; }
+        [Location("Energy Tank, Wrecked Ship")]
+        protected abstract List<Case> EnergyTankWreckedShip { get; }
+        [Location("Super Missile (Wrecked Ship left)")]
+        protected abstract List<Case> SuperMissileWreckedShipLeft { get; }
+        [Location("Right Super, Wrecked Ship")]
+        protected abstract List<Case> SuperMissileWreckedShipRight { get; }
+        [Location("Gravity Suit")]
+        protected abstract List<Case> GravitySuit { get; }
+
+        [Region("Brinstar Blue")]
+        protected abstract List<Case> BrinstarBlue { get; }
+        [Location("Morphing Ball")]
+        protected abstract List<Case> MorphingBall { get; }
+        [Location("Power Bomb (blue Brinstar)")]
+        protected abstract List<Case> PowerBombBlueBrinstar { get; }
+        [Location("Missile (blue Brinstar middle)")]
+        protected abstract List<Case> MissileBlueBrinstarMiddle { get; }
+        [Location("Energy Tank, Brinstar Ceiling")]
+        protected abstract List<Case> EnergyTankBrinstarCeiling { get; }
+        [Location("Missile (blue Brinstar bottom)")]
+        protected abstract List<Case> MissileBlueBrinstarBottom { get; }
+        [Location("Missile (blue Brinstar top)")]
+        [Location("Missile (blue Brinstar behind missile)")]
+        protected abstract List<Case> MissileBlueBrinstarBillyMays { get; }
+
+        [Region("Brinstar Green")]
+        protected abstract List<Case> BrinstarGreen { get; }
+        [Location("Power Bomb (green Brinstar bottom)")]
+        protected abstract List<Case> PowerBombGreenBrinstarBottom { get; }
+        [Location("Missile (green Brinstar below super missile)")]
+        protected abstract List<Case> MissileGreenBrinstarBelowSuperMissile { get; }
+        [Location("Super Missile (green Brinstar top)")]
+        protected abstract List<Case> SuperMissileGreenBrinstarTop { get; }
+        [Location("Reserve Tank, Brinstar")]
+        protected abstract List<Case> ReserveTankBrinstar { get; }
+        [Location("Missile (green Brinstar behind missile)")]
+        protected abstract List<Case> MissileGreenBrinstarBehindMissile { get; }
+        [Location("Missile (green Brinstar behind reserve tank)")]
+        protected abstract List<Case> MissileGreenBrinstarBehindReserveTank { get; }
+        [Location("Energy Tank, Etecoons")]
+        protected abstract List<Case> EnergyTankEtecoons { get; }
+        [Location("Super Missile (green Brinstar bottom)")]
+        protected abstract List<Case> SuperMissileGreenBrinstarBottom { get; }
+
+        [Region("Brinstar Pink")]
+        protected abstract List<Case> BrinstarPink { get; }
+        [Location("Super Missile (pink Brinstar)")]
+        protected abstract List<Case> SuperMissilePinkBrinstar { get; }
+        [Location("Missile (pink Brinstar top)")]
+        [Location("Missile (pink Brinstar bottom)")]
+        protected abstract List<Case> MissilePinkBrinstarRoom { get; }
+        [Location("Charge Beam")]
+        protected abstract List<Case> ChargeBeam { get; }
+        [Location("Power Bomb (pink Brinstar)")]
+        protected abstract List<Case> PowerBombPinkBrinstar { get; }
+        [Location("Missile (green Brinstar pipe)")]
+        protected abstract List<Case> MissileGreenBrinstarPipe { get; }
+        [Location("Energy Tank, Waterway")]
+        protected abstract List<Case> EnergyTankWaterway { get; }
+        [Location("Energy Tank, Brinstar Gate")]
+        protected abstract List<Case> EnergyTankBrinstarGate { get; }
+
+        [Region("Brinstar Red")]
+        protected abstract List<Case> BrinstarRed { get; }
+        [Location("X-Ray Scope")]
+        protected abstract List<Case> XRayScope { get; }
+        [Location("Power Bomb (red Brinstar sidehopper room)")]
+        protected abstract List<Case> PowerBombRedBrinstarSidehopperRoom { get; }
+        [Location("Power Bomb (red Brinstar spike room)")]
+        protected abstract List<Case> PowerBombRedBrinstarSpikeRoom { get; }
+        [Location("Missile (red Brinstar spike room)")]
+        protected abstract List<Case> MissileRedBrinstarSpikeRoom { get; }
+        [Location("Spazer")]
+        protected abstract List<Case> Spazer { get; }
+
+        [Region("Brinstar Kraid")]
+        protected abstract List<Case> BrinstarKraid { get; }
+        [Location("Energy Tank, Kraid")]
+        protected abstract List<Case> EnergyTankKraid { get; }
+        [Location("Varia Suit")]
+        protected abstract List<Case> VariaSuit { get; }
+        [Location("Missile (Kraid)")]
+        protected abstract List<Case> MissileKraid { get; }
+
+        [Region("Maridia Outer")]
+        protected abstract List<Case> MaridiaOuter { get; }
+        [Location("Missile (green Maridia shinespark)")]
+        protected abstract List<Case> MissileGreenMaridiaShinespark { get; }
+        [Location("Super Missile (green Maridia)")]
+        protected abstract List<Case> SuperMissileGreenMaridia { get; }
+        [Location("Energy Tank, Mama turtle")]
+        protected abstract List<Case> EnergyTankMamaTurtle { get; }
+        [Location("Missile (green Maridia tatori)")]
+        protected abstract List<Case> MissileGreenMaridiaTatori { get; }
+
+        [Region("Maridia Inner")]
+        protected abstract List<Case> MaridiaInner { get; }
+        [Location("Super Missile (yellow Maridia)")]
+        [Location("Missile (yellow Maridia super missile)")]
+        protected abstract List<Case> YellowMaridiaWateringHole { get; }
+        [Location("Missile (yellow Maridia false wall)")]
+        protected abstract List<Case> MissileYellowMaridiaFalseWall { get; }
+        [Location("Plasma Beam")]
+        protected abstract List<Case> PlasmaBeam { get; }
+        [Location("Missile (left Maridia sand pit room)")]
+        [Location("Reserve Tank, Maridia")]
+        protected abstract List<Case> LeftMaridiaSandPitRoom { get; }
+        [Location("Missile (right Maridia sand pit room)")]
+        protected abstract List<Case> MissileRightMaridiaSandPitRoom { get; }
+        [Location("Power Bomb (right Maridia sand pit room)")]
+        protected abstract List<Case> PowerBombRightMaridiaSandPitRoom { get; }
+        [Location("Missile (pink Maridia)")]
+        [Location("Super Missile (pink Maridia)")]
+        protected abstract List<Case> PinkMaridia { get; }
+        [Location("Spring Ball")]
+        protected abstract List<Case> SpringBall { get; }
+        [Location("Missile (Draygon)")]
+        protected abstract List<Case> MissileDraygon { get; }
+        [Location("Energy Tank, Botwoon")]
+        protected abstract List<Case> EnergyTankBotwoon { get; }
+        [Location("Space Jump")]
+        protected abstract List<Case> SpaceJump { get; }
+
+        [Region("Norfair Upper West")]
+        protected abstract List<Case> NorfairUpperWest { get; }
+        [Location("Missile (lava room)")]
+        protected abstract List<Case> MissileLavaRoom { get; }
+        [Location("Ice Beam")]
+        protected abstract List<Case> IceBeam { get; }
+        [Location("Missile (below Ice Beam)")]
+        protected abstract List<Case> MissileBelowIceBeam { get; }
+        [Location("Hi-Jump Boots")]
+        protected abstract List<Case> HiJumpBoots { get; }
+        [Location("Missile (Hi-Jump Boots)")]
+        protected abstract List<Case> MissileHiJumpBoots { get; }
+        [Location("Energy Tank (Hi-Jump Boots)")]
+        protected abstract List<Case> EnergyTankHiJumpBoots { get; }
+
+        [Region("Norfair Upper East")]
+        protected abstract List<Case> NorfairUpperEast { get; }
+        [Location("Reserve Tank, Norfair")]
+        protected abstract List<Case> ReserveTankNorfair { get; }
+        [Location("Missile (Norfair Reserve Tank)")]
+        protected abstract List<Case> MissileNorfairReserveTank { get; }
+        [Location("Missile (bubble Norfair green door)")]
+        protected abstract List<Case> MissileBubbleNorfairGreenDoor { get; }
+        [Location("Missile (bubble Norfair)")]
+        protected abstract List<Case> MissileBubbleNorfair { get; }
+        [Location("Missile (Speed Booster)")]
+        protected abstract List<Case> MissileSpeedBooster { get; }
+        [Location("Speed Booster")]
+        protected abstract List<Case> SpeedBooster { get; }
+        [Location("Missile (Wave Beam)")]
+        protected abstract List<Case> MissileWaveBeam { get; }
+        [Location("Wave Beam")]
+        protected abstract List<Case> WaveBeam { get; }
+
+        [Region("Norfair Upper Crocomire")]
+        protected abstract List<Case> NorfairUpperCrocomire { get; }
+        [Location("Energy Tank, Crocomire")]
+        protected abstract List<Case> EnergyTankCrocomire { get; }
+        [Location("Missile (above Crocomire)")]
+        protected abstract List<Case> MissileAboveCrocomire { get; }
+        [Location("Power Bomb (Crocomire)")]
+        protected abstract List<Case> PowerBombCrocomire { get; }
+        [Location("Missile (below Crocomire)")]
+        protected abstract List<Case> MissileBelowCrocomire { get; }
+        [Location("Missile (Grappling Beam)")]
+        protected abstract List<Case> MissileGrapplingBeam { get; }
+        [Location("Grappling Beam")]
+        protected abstract List<Case> GrapplingBeam { get; }
+
+        [Region("Norfair Lower West")]
+        protected abstract List<Case> NorfairLowerWest { get; }
+        [Location("Missile (Gold Torizo)")]
+        protected abstract List<Case> MissileGoldTorizo { get; }
+        [Location("Super Missile (Gold Torizo)")]
+        protected abstract List<Case> SuperMissileGoldTorizo { get; }
+        [Location("Screw Attack")]
+        protected abstract List<Case> ScrewAttack { get; }
+        [Location("Missile (Mickey Mouse room)")]
+        protected abstract List<Case> MissileMickeyMouseRoom { get; }
+
+        [Region("Norfair Lower East")]
+        protected abstract List<Case> NorfairLowerEast { get; }
+        [Location("Missile (lower Norfair above fire flea room)")]
+        protected abstract List<Case> MissileLowerNorfairAboveFireFleaRoom { get; }
+        [Location("Power Bomb (lower Norfair above fire flea room)")]
+        protected abstract List<Case> PowerBombLowerNorfairAboveFireFleaRoom { get; }
+        [Location("Power Bomb (Power Bombs of shame)")]
+        protected abstract List<Case> PowerBombPowerBombsOfShame { get; }
+        [Location("Missile (lower Norfair near Wave Beam)")]
+        protected abstract List<Case> MissileLowerNorfairNearWaveBeam { get; }
+        [Location("Energy Tank, Ridley")]
+        protected abstract List<Case> EnergyTankRidley { get; }
+        [Location("Energy Tank, Firefleas")]
+        protected abstract List<Case> EnergyTankFirefleas { get; }
+
+        [Region("Light World Death Mountain West")]
+        protected abstract List<Case> LightWorldDeathMountainWest { get; }
+        [Location("Ether Tablet")]
+        protected abstract List<Case> EtherTablet { get; }
+        [Location("Spectacle Rock")]
+        protected abstract List<Case> SpectacleRock { get; }
+        [Location("Spectacle Rock Cave")]
+        protected abstract List<Case> SpectacleRockCave { get; }
+        [Location("Old Man")]
+        protected abstract List<Case> OldMan { get; }
+
+        [Region("Light World Death Mountain East")]
+        protected abstract List<Case> LightWorldDeathMountainEast { get; }
+        [Location("Floating Island")]
+        protected abstract List<Case> FloatingIsland { get; }
+        [Location("Spiral Cave")]
+        protected abstract List<Case> SpiralCave { get; }
+        [Location("Paradox Cave Upper - Left")]
+        [Location("Paradox Cave Upper - Right")]
+        [Location("Paradox Cave Lower - Far Left")]
+        [Location("Paradox Cave Lower - Left")]
+        [Location("Paradox Cave Lower - Middle")]
+        [Location("Paradox Cave Lower - Right")]
+        [Location("Paradox Cave Lower - Far Right")]
+        protected abstract List<Case> ParadoxCave { get; }
+        [Location("Mimic Cave")]
+        protected abstract List<Case> MimicCave { get; }
+
+        [Region("Light World North West")]
+        protected abstract List<Case> LightWorldNorthWest { get; }
+        [Location("Master Sword Pedestal")]
+        protected abstract List<Case> MasterSwordPedestal { get; }
+        [Location("Mushroom")]
+        protected abstract List<Case> Mushroom { get; }
+        [Location("Lost Woods Hideout")]
+        protected abstract List<Case> LostWoodsHideout { get; }
+        [Location("Lumberjack Tree")]
+        protected abstract List<Case> LumberjackTree { get; }
+        [Location("Pegasus Rocks")]
+        protected abstract List<Case> PegasusRocks { get; }
+        [Location("Graveyard Ledge")]
+        protected abstract List<Case> GraveyardLedge { get; }
+        [Location("King's Tomb")]
+        protected abstract List<Case> KingsTomb { get; }
+        [Location("Kakariko Well - Top")]
+        [Location("Kakariko Well - Left")]
+        [Location("Kakariko Well - Middle")]
+        [Location("Kakariko Well - Right")]
+        [Location("Kakariko Well - Bottom")]
+        protected abstract List<Case> KakarikoWell { get; }
+        [Location("Blind's Hideout - Top")]
+        [Location("Blind's Hideout - Far Left")]
+        [Location("Blind's Hideout - Left")]
+        [Location("Blind's Hideout - Right")]
+        [Location("Blind's Hideout - Far Right")]
+        protected abstract List<Case> BlindsHideout { get; }
+        [Location("Bottle Merchant")]
+        protected abstract List<Case> BottleMerchant { get; }
+        [Location("Chicken House")]
+        protected abstract List<Case> ChickenHouse { get; }
+        [Location("Sick Kid")]
+        protected abstract List<Case> SickKid { get; }
+        [Location("Kakariko Tavern")]
+        protected abstract List<Case> KakarikoTavern { get; }
+        [Location("Magic Bat")]
+        protected abstract List<Case> MagicBat { get; }
+
+        [Region("Light World North East")]
+        protected abstract List<Case> LightWorldNorthEast { get; }
+        [Location("King Zora")]
+        protected abstract List<Case> KingZora { get; }
+        [Location("Zora's Ledge")]
+        protected abstract List<Case> ZorasLedge { get; }
+        [Location("Waterfall Fairy - Left")]
+        [Location("Waterfall Fairy - Right")]
+        protected abstract List<Case> WaterfallFairy { get; }
+        [Location("Potion Shop")]
+        protected abstract List<Case> PotionShop { get; }
+        [Location("Sahasrahla's Hut - Left")]
+        [Location("Sahasrahla's Hut - Middle")]
+        [Location("Sahasrahla's Hut - Right")]
+        protected abstract List<Case> SahasrahlasHut { get; }
+        [Location("Sahasrahla")]
+        protected abstract List<Case> Sahasrahla { get; }
+
+        [Region("Light World South")]
+        protected abstract List<Case> LightWorldSouth { get; }
+        [Location("Maze Race")]
+        protected abstract List<Case> MazeRace { get; }
+        [Location("Library")]
+        protected abstract List<Case> Library { get; }
+        [Location("Flute Spot")]
+        protected abstract List<Case> FluteSpot { get; }
+        [Location("South of Grove")]
+        protected abstract List<Case> SouthOfGrove { get; }
+        [Location("Link's House")]
+        protected abstract List<Case> LinksHouse { get; }
+        [Location("Aginah's Cave")]
+        protected abstract List<Case> AginahsCave { get; }
+        [Location("Mini Moldorm Cave - Far Left")]
+        [Location("Mini Moldorm Cave - Left")]
+        [Location("Mini Moldorm Cave - NPC")]
+        [Location("Mini Moldorm Cave - Right")]
+        [Location("Mini Moldorm Cave - Far Right")]
+        protected abstract List<Case> MiniMoldormCave { get; }
+        [Location("Desert Ledge")]
+        protected abstract List<Case> DesertLedge { get; }
+        [Location("Checkerboard Cave")]
+        protected abstract List<Case> CheckerboardCave { get; }
+        [Location("Bombos Tablet")]
+        protected abstract List<Case> BombosTablet { get; }
+        [Location("Floodgate Chest")]
+        protected abstract List<Case> FloodgateChest { get; }
+        [Location("Sunken Treasure")]
+        protected abstract List<Case> SunkenTreasure { get; }
+        [Location("Lake Hylia Island")]
+        protected abstract List<Case> LakeHyliaIsland { get; }
+        [Location("Hobo")]
+        protected abstract List<Case> Hobo { get; }
+        [Location("Ice Rod Cave")]
+        protected abstract List<Case> IceRodCave { get; }
+
+        [Region("Dark World Death Mountain West")]
+        protected abstract List<Case> DarkWorldDeathMountainWest { get; }
+        [Location("Spike Cave")]
+        protected abstract List<Case> SpikeCave { get; }
+
+        [Region("Dark World Death Mountain East")]
+        protected abstract List<Case> DarkWorldDeathMountainEast { get; }
+        [Location("Hookshot Cave - Top Right")]
+        [Location("Hookshot Cave - Top Left")]
+        [Location("Hookshot Cave - Bottom Left")]
+        protected abstract List<Case> HookshotCave { get; }
+        [Location("Hookshot Cave - Bottom Right")]
+        protected abstract List<Case> HookshotCaveBottomRight { get; }
+        [Location("Superbunny Cave - Top")]
+        [Location("Superbunny Cave - Bottom")]
+        protected abstract List<Case> SuperbunnyCave { get; }
+
+        [Region("Dark World North West")]
+        protected abstract List<Case> DarkWorldNorthWest { get; }
+        [Location("Bumper Cave")]
+        protected abstract List<Case> BumperCave { get; }
+        [Location("Chest Game")]
+        [Location("C-Shaped House")]
+        [Location("Brewery")]
+        protected abstract List<Case> VillageOfOutcasts { get; }
+        [Location("Hammer Pegs")]
+        protected abstract List<Case> HammerPegs { get; }
+        [Location("Blacksmith")]
+        protected abstract List<Case> Blacksmith { get; }
+        [Location("Purple Chest")]
+        protected abstract List<Case> PurpleChest { get; }
+
+        [Region("Dark World North East")]
+        protected abstract List<Case> DarkWorldNorthEast { get; }
+        [Location("Catfish")]
+        protected abstract List<Case> Catfish { get; }
+        [Location("Pyramid")]
+        protected abstract List<Case> Pyramid { get; }
+        [Location("Pyramid Fairy - Left")]
+        [Location("Pyramid Fairy - Right")]
+        protected abstract List<Case> PyramidFairy { get; }
+
+        [Region("Dark World South")]
+        protected abstract List<Case> DarkWorldSouth { get; }
+        [Location("Digging Game")]
+        protected abstract List<Case> DiggingGame { get; }
+        [Location("Stumpy")]
+        protected abstract List<Case> Stumpy { get; }
+        [Location("Hype Cave - Top")]
+        [Location("Hype Cave - Middle Right")]
+        [Location("Hype Cave - Middle Left")]
+        [Location("Hype Cave - Bottom")]
+        [Location("Hype Cave - NPC")]
+        protected abstract List<Case> HypeCave { get; }
+
+        [Region("Dark World Mire")]
+        protected abstract List<Case> DarkWorldMire { get; }
+        [Location("Mire Shed - Left")]
+        [Location("Mire Shed - Right")]
+        protected abstract List<Case> MireShed { get; }
+
+        [Region("Hyrule Castle")]
+        protected abstract List<Case> HyruleCastle { get; }
+        [Location("Sanctuary")]
+        protected abstract List<Case> Sanctuary { get; }
+        [Location("Sewers - Secret Room - Left")]
+        [Location("Sewers - Secret Room - Middle")]
+        [Location("Sewers - Secret Room - Right")]
+        protected abstract List<Case> SewersSecretRoom { get; }
+        [Location("Sewers - Dark Cross")]
+        protected abstract List<Case> SewersDarkCross { get; }
+        [Location("Hyrule Castle - Map Chest")]
+        protected abstract List<Case> HyruleCastleMapChest { get; }
+        [Location("Hyrule Castle - Boomerang Chest")]
+        protected abstract List<Case> HyruleCastleBoomerangChest { get; }
+        [Location("Hyrule Castle - Zelda's Cell")]
+        protected abstract List<Case> HyruleCastleZeldasCell { get; }
+        [Location("Link's Uncle")]
+        protected abstract List<Case> LinksUncle { get; }
+        [Location("Secret Passage")]
+        protected abstract List<Case> SecretPassage { get; }
+
+        [Region("Castle Tower")]
+        protected abstract List<Case> CastleTower { get; }
+        [Location("Castle Tower - Foyer")]
+        protected abstract List<Case> CastleTowerFoyer { get; }
+        [Location("Castle Tower - Dark Maze")]
+        protected abstract List<Case> CastleTowerDarkMaze { get; }
+
+        [Region("Eastern Palace")]
+        protected abstract List<Case> EasternPalace { get; }
+        [Location("Eastern Palace - Cannonball Chest")]
+        protected abstract List<Case> EasternPalaceCannonballChest { get; }
+        [Location("Eastern Palace - Map Chest")]
+        protected abstract List<Case> EasternPalaceMapChest { get; }
+        [Location("Eastern Palace - Compass Chest")]
+        protected abstract List<Case> EasternPalaceCompassChest { get; }
+        [Location("Eastern Palace - Big Chest")]
+        protected abstract List<Case> EasternPalaceBigChest { get; }
+        [Location("Eastern Palace - Big Key Chest")]
+        protected abstract List<Case> EasternPalaceBigKeyChest { get; }
+        [Location("Eastern Palace - Armos Knights")]
+        protected abstract List<Case> EasternPalaceArmosKnights { get; }
+
+        [Region("Desert Palace")]
+        protected abstract List<Case> DesertPalace { get; }
+        [Location("Desert Palace - Big Chest")]
+        protected abstract List<Case> DesertPalaceBigChest { get; }
+        [Location("Desert Palace - Torch")]
+        protected abstract List<Case> DesertPalaceTorch { get; }
+        [Location("Desert Palace - Map Chest")]
+        protected abstract List<Case> DesertPalaceMapChest { get; }
+        [Location("Desert Palace - Big Key Chest")]
+        protected abstract List<Case> DesertPalaceBigKeyChest { get; }
+        [Location("Desert Palace - Compass Chest")]
+        protected abstract List<Case> DesertPalaceCompassChest { get; }
+        [Location("Desert Palace - Lanmolas")]
+        protected abstract List<Case> DesertPalaceLanmolas { get; }
+
+        [Region("Tower of Hera")]
+        protected abstract List<Case> TowerOfHera { get; }
+        [Location("Tower of Hera - Basement Cage")]
+        protected abstract List<Case> TowerOfHeraBasementCage { get; }
+        [Location("Tower of Hera - Map Chest")]
+        protected abstract List<Case> TowerOfHeraMapChest { get; }
+        [Location("Tower of Hera - Big Key Chest")]
+        protected abstract List<Case> TowerOfHeraBigKeyChest { get; }
+        [Location("Tower of Hera - Compass Chest")]
+        protected abstract List<Case> TowerOfHeraCompassChest { get; }
+        [Location("Tower of Hera - Big Chest")]
+        protected abstract List<Case> TowerOfHeraBigChest { get; }
+        [Location("Tower of Hera - Moldorm")]
+        protected abstract List<Case> TowerOfHeraMoldorm { get; }
+
+        [Region("Palace of Darkness")]
+        protected abstract List<Case> PalaceOfDarkness { get; }
+        [Location("Palace of Darkness - Shooter Room")]
+        protected abstract List<Case> PalaceOfDarknessShooterRoom { get; }
+        [Location("Palace of Darkness - Big Key Chest")]
+        protected abstract List<Case> PalaceOfDarknessBigKeyChest { get; }
+        [Location("Palace of Darkness - Stalfos Basement")]
+        protected abstract List<Case> PalaceOfDarknessStalfosBasement { get; }
+        [Location("Palace of Darkness - The Arena - Bridge")]
+        protected abstract List<Case> PalaceOfDarknessTheArenaBridge { get; }
+        [Location("Palace of Darkness - The Arena - Ledge")]
+        protected abstract List<Case> PalaceOfDarknessTheArenaLedge { get; }
+        [Location("Palace of Darkness - Map Chest")]
+        protected abstract List<Case> PalaceOfDarknessMapChest { get; }
+        [Location("Palace of Darkness - Compass Chest")]
+        protected abstract List<Case> PalaceOfDarknessCompassChest { get; }
+        [Location("Palace of Darkness - Harmless Hellway")]
+        protected abstract List<Case> PalaceOfDarknessHarmlessHellway { get; }
+        [Location("Palace of Darkness - Dark Basement - Left")]
+        [Location("Palace of Darkness - Dark Basement - Right")]
+        protected abstract List<Case> PalaceOfDarknessDarkBasement { get; }
+        [Location("Palace of Darkness - Dark Maze - Top")]
+        [Location("Palace of Darkness - Dark Maze - Bottom")]
+        protected abstract List<Case> PalaceOfDarknessDarkMaze { get; }
+        [Location("Palace of Darkness - Big Chest")]
+        protected abstract List<Case> PalaceOfDarknessBigChest { get; }
+        [Location("Palace of Darkness - Helmasaur King")]
+        protected abstract List<Case> PalaceOfDarknessHelmasaurKing { get; }
+
+        [Region("Swamp Palace")]
+        protected abstract List<Case> SwampPalace { get; }
+        [Location("Swamp Palace - Entrance")]
+        protected abstract List<Case> SwampPalaceEntrance { get; }
+        [Location("Swamp Palace - Map Chest")]
+        protected abstract List<Case> SwampPalaceMapChest { get; }
+        [Location("Swamp Palace - Big Chest")]
+        protected abstract List<Case> SwampPalaceBigChest { get; }
+        [Location("Swamp Palace - Compass Chest")]
+        protected abstract List<Case> SwampPalaceCompassChest { get; }
+        [Location("Swamp Palace - West Chest")]
+        [Location("Swamp Palace - Big Key Chest")]
+        protected abstract List<Case> SwampPalaceWestWing { get; }
+        [Location("Swamp Palace - Flooded Room - Left")]
+        [Location("Swamp Palace - Flooded Room - Right")]
+        protected abstract List<Case> SwampPalaceFloodedRoom { get; }
+        [Location("Swamp Palace - Waterfall Room")]
+        protected abstract List<Case> SwampPalaceWaterfallRoom { get; }
+        [Location("Swamp Palace - Arrghus")]
+        protected abstract List<Case> SwampPalaceArrghus { get; }
+
+        [Region("Skull Woods")]
+        protected abstract List<Case> SkullWoods { get; }
+        [Location("Skull Woods - Pot Prison")]
+        protected abstract List<Case> SkullWoodsPotPrison { get; }
+        [Location("Skull Woods - Compass Chest")]
+        protected abstract List<Case> SkullWoodsCompassChest { get; }
+        [Location("Skull Woods - Big Chest")]
+        protected abstract List<Case> SkullWoodsBigChest { get; }
+        [Location("Skull Woods - Map Chest")]
+        protected abstract List<Case> SkullWoodsMapChest { get; }
+        // Skipping "Skull Woods - Pinball Room" since it is always a key
+        [Location("Skull Woods - Big Key Chest")]
+        protected abstract List<Case> SkullWoodsBigKeyChest { get; }
+        [Location("Skull Woods - Bridge Room")]
+        protected abstract List<Case> SkullWoodsBridgeRoom { get; }
+        [Location("Skull Woods - Mothula")]
+        protected abstract List<Case> SkullWoodsMothula { get; }
+
+        [Region("Thieves' Town")]
+        protected abstract List<Case> ThievesTown { get; }
+        [Location("Thieves' Town - Map Chest")]
+        [Location("Thieves' Town - Ambush Chest")]
+        [Location("Thieves' Town - Compass Chest")]
+        [Location("Thieves' Town - Big Key Chest")]
+        protected abstract List<Case> ThievesTownCourtyard { get; }
+        [Location("Thieves' Town - Attic")]
+        protected abstract List<Case> ThievesTownAttic { get; }
+        [Location("Thieves' Town - Blind's Cell")]
+        protected abstract List<Case> ThievesTownBlindsCell { get; }
+        [Location("Thieves' Town - Big Chest")]
+        protected abstract List<Case> ThievesTownBigChest { get; }
+
+        [Location("Thieves' Town - Blind")]
+        protected abstract List<Case> ThievesTownBlind { get; }
+
+        [Region("Ice Palace")]
+        protected abstract List<Case> IcePalace { get; }
+        [Location("Ice Palace - Compass Chest")]
+        protected abstract List<Case> IcePalaceCompassChest { get; }
+        [Location("Ice Palace - Spike Room")]
+        protected abstract List<Case> IcePalaceSpikeRoom { get; }
+        [Location("Ice Palace - Map Chest")]
+        protected abstract List<Case> IcePalaceMapChest { get; }
+        [Location("Ice Palace - Big Key Chest")]
+        protected abstract List<Case> IcePalaceBigKeyChest { get; }
+        [Location("Ice Palace - Iced T Room")]
+        protected abstract List<Case> IcePalaceIcedTRoom { get; }
+        [Location("Ice Palace - Freezor Chest")]
+        protected abstract List<Case> IcePalaceFreezorChest { get; }
+        [Location("Ice Palace - Big Chest")]
+        protected abstract List<Case> IcePalaceBigChest { get; }
+        [Location("Ice Palace - Kholdstare")]
+        protected abstract List<Case> IcePalaceKholdstare { get; }
+
+        [Region("Misery Mire")]
+        protected abstract List<Case> MiseryMire { get; }
+        [Location("Misery Mire - Main Lobby")]
+        protected abstract List<Case> MiseryMireMainLobby { get; }
+        [Location("Misery Mire - Map Chest")]
+        protected abstract List<Case> MiseryMireMapChest { get; }
+        [Location("Misery Mire - Bridge Chest")]
+        protected abstract List<Case> MiseryMireBridgeChest { get; }
+        [Location("Misery Mire - Spike Chest")]
+        protected abstract List<Case> MiseryMireSpikeChest { get; }
+        [Location("Misery Mire - Compass Chest")]
+        protected abstract List<Case> MiseryMireCompassChest { get; }
+        [Location("Misery Mire - Big Key Chest")]
+        protected abstract List<Case> MiseryMireBigKeyChest { get; }
+        [Location("Misery Mire - Big Chest")]
+        protected abstract List<Case> MiseryMireBigChest { get; }
+        [Location("Misery Mire - Vitreous")]
+        protected abstract List<Case> MiseryMireVitreous { get; }
+
+        [Region("Turtle Rock")]
+        protected abstract List<Case> TurtleRock { get; }
+        [Location("Turtle Rock - Compass Chest")]
+        protected abstract List<Case> TurtleRockCompassChest { get; }
+        [Location("Turtle Rock - Roller Room - Left")]
+        [Location("Turtle Rock - Roller Room - Right")]
+        protected abstract List<Case> TurtleRockRollerRoom { get; }
+        [Location("Turtle Rock - Chain Chomps")]
+        protected abstract List<Case> TurtleRockChainChomps { get; }
+        [Location("Turtle Rock - Big Key Chest")]
+        protected abstract List<Case> TurtleRockBigKeyChest { get; }
+        [Location("Turtle Rock - Big Chest")]
+        protected abstract List<Case> TurtleRockBigChest { get; }
+        [Location("Turtle Rock - Crystaroller Room")]
+        protected abstract List<Case> TurtleRockCrystarollerRoom { get; }
+        [Location("Turtle Rock - Eye Bridge - Top Right")]
+        [Location("Turtle Rock - Eye Bridge - Top Left")]
+        [Location("Turtle Rock - Eye Bridge - Bottom Right")]
+        [Location("Turtle Rock - Eye Bridge - Bottom Left")]
+        protected abstract List<Case> TurtleRockEyeBridge { get; }
+        [Location("Turtle Rock - Trinexx")]
+        protected abstract List<Case> TurtleRockTrinexx { get; }
+
+        [Region("Ganon's Tower")]
+        protected abstract List<Case> GanonsTower { get; }
+        [Location("Ganon's Tower - Bob's Torch")]
+        protected abstract List<Case> GanonsTowerBobsTorch { get; }
+        [Location("Ganon's Tower - DMs Room - Top Left")]
+        [Location("Ganon's Tower - DMs Room - Top Right")]
+        [Location("Ganon's Tower - DMs Room - Bottom Left")]
+        [Location("Ganon's Tower - DMs Room - Bottom Right")]
+        protected abstract List<Case> GanonsTowerDMsRoom { get; }
+        [Location("Ganon's Tower - Map Chest")]
+        protected abstract List<Case> GanonsTowerMapChest { get; }
+        [Location("Ganon's Tower - Firesnake Room")]
+        protected abstract List<Case> GanonsTowerFiresnakeRoom { get; }
+        [Location("Ganon's Tower - Randomizer Room - Top Left")]
+        protected abstract List<Case> GanonsTowerRandomizerRoomTopLeft { get; }
+        [Location("Ganon's Tower - Randomizer Room - Top Right")]
+        protected abstract List<Case> GanonsTowerRandomizerRoomTopRight { get; }
+        [Location("Ganon's Tower - Randomizer Room - Bottom Left")]
+        protected abstract List<Case> GanonsTowerRandomizerRoomBottomLeft { get; }
+        [Location("Ganon's Tower - Randomizer Room - Bottom Right")]
+        protected abstract List<Case> GanonsTowerRandomizerRoomBottomRight { get; }
+        [Location("Ganon's Tower - Hope Room - Left")]
+        [Location("Ganon's Tower - Hope Room - Right")]
+        protected abstract List<Case> GanonsTowerHopeRoom { get; }
+        [Location("Ganon's Tower - Tile Room")]
+        protected abstract List<Case> GanonsTowerTileRoom { get; }
+        [Location("Ganon's Tower - Compass Room - Top Left")]
+        protected abstract List<Case> GanonsTowerCompassRoomTopLeft { get; }
+        [Location("Ganon's Tower - Compass Room - Top Right")]
+        protected abstract List<Case> GanonsTowerCompassRoomTopRight { get; }
+        [Location("Ganon's Tower - Compass Room - Bottom Left")]
+        protected abstract List<Case> GanonsTowerCompassRoomBottomLeft { get; }
+        [Location("Ganon's Tower - Compass Room - Bottom Right")]
+        protected abstract List<Case> GanonsTowerCompassRoomBottomRight { get; }
+        [Location("Ganon's Tower - Bob's Chest")]
+        protected abstract List<Case> GanonsTowerBobsChest { get; }
+        [Location("Ganon's Tower - Big Chest")]
+        protected abstract List<Case> GanonsTowerBigChest { get; }
+        [Location("Ganon's Tower - Big Key Chest")]
+        [Location("Ganon's Tower - Big Key Room - Left")]
+        [Location("Ganon's Tower - Big Key Room - Right")]
+        protected abstract List<Case> GanonsTowerBigKeyRoom { get; }
+        [Location("Ganon's Tower - Mini Helmasaur Room - Left")]
+        [Location("Ganon's Tower - Mini Helmasaur Room - Right")]
+        [Location("Ganon's Tower - Pre-Moldorm Chest")]
+        protected abstract List<Case> GanonsTowerAscent { get; }
+        [Location("Ganon's Tower - Moldorm Chest")]
+        protected abstract List<Case> GanonsTowerMoldormChest { get; }
+
+        #endregion
+
+        [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
+        abstract class LocalityAttribute : Attribute {
+            public string Name { get; init; }
+            public LocalityAttribute(string name) { Name = name; }
+        }
+
+        class RegionAttribute : LocalityAttribute {
+            public RegionAttribute(string name) : base(name) { }
+        }
+
+        class LocationAttribute : LocalityAttribute {
+            public LocationAttribute(string name) : base(name) { }
+        }
+
+    }
+
+}

--- a/Randomizer.SMZ3.Tests/Logic/LogicTests.cs
+++ b/Randomizer.SMZ3.Tests/Logic/LogicTests.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Randomizer.SMZ3.Regions.Zelda;
+using static System.Linq.Enumerable;
+using static Randomizer.SMZ3.ItemType;
+using static Randomizer.SMZ3.RewardType;
+using static Randomizer.SMZ3.Tests.Logic.LogicCases;
+
+namespace Randomizer.SMZ3.Tests.Logic {
+
+    public class LogicTests {
+
+        World world;
+
+        internal void Setup(SMLogic smLogic, bool keysanity = false) {
+            var config = new Config {
+                SMLogic = smLogic,
+                KeyShuffle = keysanity ? KeyShuffle.Keysanity : KeyShuffle.None,
+            };
+            world = new World(config, "", 0, "");
+            (world.Regions.Single(x => x.Name == "Misery Mire") as MiseryMire).Medallion = Ether;
+            (world.Regions.Single(x => x.Name == "Turtle Rock") as TurtleRock).Medallion = Quake;
+            /* Here we use the assumptions that single/multiple reward checks yield true if the rewards are missing */
+            foreach (var region in world.Regions.OfType<IReward>()) {
+                region.Reward = region.Reward == Agahnim ? Agahnim : None;
+            }
+        }
+
+        [TestFixture]
+        public class SMNormalTests : LogicTests {
+
+            [SetUp]
+            public void Setup() => Setup(SMLogic.Normal);
+
+            [TestCaseSource(nameof(Regions))]
+            public void CanEnterRegion(string name, Case list)
+                => AssertThatRegionLogicIsSound(name, list);
+
+            [TestCaseSource(nameof(Locations))]
+            public void CanAccessLocation(string name, Case list)
+                => AssertThatLocationLogicIsSound(name, list);
+
+            public static IEnumerable<TestCaseData> Regions() => LogicCaseData(ForRegionsUsing<SMNormal>());
+            public static IEnumerable<TestCaseData> Locations() => LogicCaseData(ForLocationsUsing<SMNormal>());
+
+        }
+
+        [TestFixture]
+        public class SMHardTests : LogicTests {
+
+            [SetUp]
+            public void Setup() => Setup(SMLogic.Hard);
+
+            [TestCaseSource(nameof(Regions))]
+            public void CanEnterRegion(string name, Case list)
+                => AssertThatRegionLogicIsSound(name, list);
+
+            [TestCaseSource(nameof(Locations))]
+            public void CanAccessLocation(string name, Case list)
+                => AssertThatLocationLogicIsSound(name, list);
+
+            public static IEnumerable<TestCaseData> Regions() => LogicCaseData(ForRegionsUsing<SMHard>());
+            public static IEnumerable<TestCaseData> Locations() => LogicCaseData(ForLocationsUsing<SMHard>());
+
+        }
+
+        [TestFixture]
+        public class SMNormalKeysanityTests : LogicTests {
+
+            [SetUp]
+            public void Setup() => Setup(SMLogic.Normal, keysanity: true);
+
+            [TestCaseSource(nameof(Regions))]
+            public void CanEnterRegion(string name, Case list)
+                => AssertThatRegionLogicIsSound(name, list, keysanity: true);
+
+            [TestCaseSource(nameof(Locations))]
+            public void CanAccessLocation(string name, Case list)
+                => AssertThatLocationLogicIsSound(name, list, keysanity: true);
+
+            public static IEnumerable<TestCaseData> Regions() => LogicCaseData(ForRegionsUsing<SMNormalKeysanity>());
+            public static IEnumerable<TestCaseData> Locations() => LogicCaseData(ForLocationsUsing<SMNormalKeysanity>());
+
+        }
+
+        [TestFixture]
+        public class SMHardKeysanityTests : LogicTests {
+
+            [SetUp]
+            public void Setup() => Setup(SMLogic.Hard, keysanity: true);
+
+            [TestCaseSource(nameof(Regions))]
+            public void CanEnterRegion(string name, Case list)
+                => AssertThatRegionLogicIsSound(name, list, keysanity: true);
+
+            [TestCaseSource(nameof(Locations))]
+            public void CanAccessLocation(string name, Case list)
+                => AssertThatLocationLogicIsSound(name, list, keysanity: true);
+
+            public static IEnumerable<TestCaseData> Regions() => LogicCaseData(ForRegionsUsing<SMHardKeysanity>());
+            public static IEnumerable<TestCaseData> Locations() => LogicCaseData(ForLocationsUsing<SMHardKeysanity>());
+
+        }
+
+        void AssertThatRegionLogicIsSound(string name, Case list, bool keysanity = false) {
+            var region = world.GetRegion(name);
+
+            AssertThatLogicIsSound(region.CanEnter, name, list, keysanity);
+        }
+
+        void AssertThatLocationLogicIsSound(string name, Case list, bool keysanity = false) {
+            var location = world.Locations.Get(name);
+
+            AssertThatLogicIsSound(location.CanAccess, name, list, keysanity);
+        }
+
+        void AssertThatLogicIsSound(Func<Progression, bool> accessWith, string name, Case @case, bool keysanity) {
+            var inventory = Arrange();
+            Assert.That(accessWith(inventory), Is.True);
+
+            foreach (var index in @case.IndicesToSkip) {
+                inventory = Arrange(index);
+                var message = @case.ElementAt(index).DescribeSkipped();
+                Assert.That(accessWith(inventory), Is.False, message);
+            }
+
+            Progression Arrange(int? index = null) {
+                foreach (var location in world.Locations) {
+                    location.Item = null;
+                }
+                var inventory = @case.Prepare(world, name, index);
+                if (!keysanity) {
+                    inventory.Add(AllKeycards(world));
+                }
+                return inventory;
+            }
+        }
+
+        static IEnumerable<TestCaseData> LogicCaseData(IEnumerable<Locality> localities) {
+            return from locality in localities
+                   from @case in locality.Cases
+                   select new TestCaseData(locality.Name, @case)
+                       .SetName($"{{m}}({{0}},\"{string.Join(" ", @case)}\")");
+        }
+
+        static IEnumerable<Item> AllKeycards(World world) {
+            yield return new Item(CardCrateriaL1, world);
+            yield return new Item(CardCrateriaL2, world);
+            yield return new Item(CardCrateriaBoss, world);
+            yield return new Item(CardBrinstarL1, world);
+            yield return new Item(CardBrinstarL2, world);
+            yield return new Item(CardBrinstarBoss, world);
+            yield return new Item(CardMaridiaL1, world);
+            yield return new Item(CardMaridiaL2, world);
+            yield return new Item(CardMaridiaBoss, world);
+            yield return new Item(CardNorfairL1, world);
+            yield return new Item(CardNorfairL2, world);
+            yield return new Item(CardNorfairBoss, world);
+            yield return new Item(CardLowerNorfairL1, world);
+            yield return new Item(CardLowerNorfairBoss, world);
+            yield return new Item(CardWreckedShipL1, world);
+            yield return new Item(CardWreckedShipBoss, world);
+        }
+
+    }
+
+}

--- a/Randomizer.SMZ3.Tests/Logic/SMHard.cs
+++ b/Randomizer.SMZ3.Tests/Logic/SMHard.cs
@@ -1,0 +1,1183 @@
+﻿using System.Collections.Generic;
+
+namespace Randomizer.SMZ3.Tests.Logic {
+
+    public class SMHard : SMNormal {
+
+        #region Crateria West
+
+        protected override List<Case> EnergyTankGauntlet => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.TwoPowerBombs),
+            CaseWith(x => x.ScrewAttack),
+            CaseWith(x => x.SpeedBooster.Morph.PowerBomb.ETank(2)),
+        };
+
+        protected override List<Case> MissileCrateriaGauntlet => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.TwoPowerBombs),
+            CaseWith(x => x.ScrewAttack.Morph.PowerBomb),
+            CaseWith(x => x.SpeedBooster.Morph.PowerBomb.ETank(2)),
+        };
+
+        #endregion
+
+        #region Crateria Central
+
+        protected override List<Case> Bombs => new() {
+            CaseWith(x => x.Missile.Morph),
+            CaseWith(x => x.Super.Morph),
+        };
+
+        #endregion
+
+        #region Crateria East
+
+        protected override List<Case> CrateriaEast => new() {
+            CaseWith(x => x.Morph.PowerBomb.Super),
+            CaseWith(x => x.Morph.PowerBomb.Flute.Ice),
+            CaseWith(x => x.Morph.PowerBomb.Flute.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Flute.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Flute.Bombs),
+            CaseWith(x => x.Morph.PowerBomb.Flute.SpringBall),
+            CaseWith(x => x.Morph.PowerBomb.Glove.Lamp.Ice),
+            CaseWith(x => x.Morph.PowerBomb.Glove.Lamp.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Glove.Lamp.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Glove.Lamp.Bombs),
+            CaseWith(x => x.Morph.PowerBomb.Glove.Lamp.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt),
+        };
+
+        protected override List<Case> MissileOutsideWreckedShipBottom => new() {
+            CaseWith(x => x.Morph),
+        };
+
+        protected override List<Case> MissilesOutsideWreckedShipTopHalf => new() {
+            CaseWith(x => x.Super.Morph.PowerBomb),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Mitt.Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.Bombs),
+        };
+
+        #endregion
+
+        #region Wrecked Ship
+
+        protected override List<Case> WreckedShip => new() {
+            CaseWith(x => x.Super.Morph.PowerBomb),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Mitt.Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt),
+        };
+
+        protected override List<Case> ReserveTankWreckedShip => new() {
+            CaseWith(x => x.Morph.PowerBomb.SpeedBooster.Varia),
+            CaseWith(x => x.Morph.PowerBomb.SpeedBooster.ETank(2)),
+        };
+
+        protected override List<Case> MissileGravitySuit => new() {
+            CaseWith(x => x.Morph.Bombs.Varia),
+            CaseWith(x => x.Morph.Bombs.ETank(1)),
+            CaseWith(x => x.Morph.PowerBomb.Varia),
+            CaseWith(x => x.Morph.PowerBomb.ETank(1)),
+        };
+
+        protected override List<Case> EnergyTankWreckedShip => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        protected override List<Case> GravitySuit => new() {
+            CaseWith(x => x.Morph.Bombs.Varia),
+            CaseWith(x => x.Morph.Bombs.ETank(1)),
+            CaseWith(x => x.Morph.PowerBomb.Varia),
+            CaseWith(x => x.Morph.PowerBomb.ETank(1)),
+        };
+
+        #endregion
+
+        #region Brinstar Blue
+
+        protected override List<Case> EnergyTankBrinstarCeiling => CaseWithNothing;
+
+        #endregion
+
+        #region Brinstar Green
+
+        protected override List<Case> SuperMissileGreenBrinstarTop => new() {
+            CaseWith(x => x.Missile.Morph),
+            CaseWith(x => x.Missile.SpeedBooster),
+            CaseWith(x => x.Super.Morph),
+            CaseWith(x => x.Super.SpeedBooster),
+        };
+        protected override List<Case> ReserveTankBrinstar => new() {
+            CaseWith(x => x.Missile.Morph),
+            CaseWith(x => x.Missile.SpeedBooster),
+            CaseWith(x => x.Super.Morph),
+            CaseWith(x => x.Super.SpeedBooster),
+        };
+
+        protected override List<Case> MissileGreenBrinstarBehindMissile => new() {
+            CaseWith(x => x.Morph.Bombs.Missile),
+            CaseWith(x => x.Morph.Bombs.Super),
+            CaseWith(x => x.Morph.PowerBomb.Missile),
+            CaseWith(x => x.Morph.PowerBomb.Super),
+            CaseWith(x => x.Morph.ScrewAttack.Missile),
+            CaseWith(x => x.Morph.ScrewAttack.Super),
+        };
+
+        protected override List<Case> MissileGreenBrinstarBehindReserveTank => new() {
+            CaseWith(x => x.Missile.Morph),
+            CaseWith(x => x.Super.Morph),
+        };
+
+        #endregion
+
+        #region Brinstar Pink
+
+        protected override List<Case> BrinstarPink => new() {
+            CaseWith(x => x.Missile.Morph.Bombs),
+            CaseWith(x => x.Missile.ScrewAttack),
+            CaseWith(x => x.Missile.SpeedBooster),
+            CaseWith(x => x.Super.Morph.Bombs),
+            CaseWith(x => x.Super.ScrewAttack),
+            CaseWith(x => x.Super.SpeedBooster),
+            CaseWith(x => x.Morph.PowerBomb),
+            CaseWith(x => x.Flute.Morph.Missile.Ice),
+            CaseWith(x => x.Flute.Morph.Missile.HiJump),
+            CaseWith(x => x.Flute.Morph.Missile.SpringBall),
+            CaseWith(x => x.Flute.Morph.Missile.SpaceJump),
+            CaseWith(x => x.Flute.Morph.Super.Ice),
+            CaseWith(x => x.Flute.Morph.Super.HiJump),
+            CaseWith(x => x.Flute.Morph.Super.SpringBall),
+            CaseWith(x => x.Flute.Morph.Super.SpaceJump),
+            CaseWith(x => x.Flute.Morph.Wave.Ice),
+            CaseWith(x => x.Flute.Morph.Wave.HiJump),
+            CaseWith(x => x.Flute.Morph.Wave.SpringBall),
+            CaseWith(x => x.Flute.Morph.Wave.SpaceJump),
+            CaseWith(x => x.Flute.Morph.Wave.Bombs),
+            CaseWith(x => x.Glove.Lamp.Morph.Missile.Ice),
+            CaseWith(x => x.Glove.Lamp.Morph.Missile.HiJump),
+            CaseWith(x => x.Glove.Lamp.Morph.Missile.SpringBall),
+            CaseWith(x => x.Glove.Lamp.Morph.Missile.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.Morph.Super.Ice),
+            CaseWith(x => x.Glove.Lamp.Morph.Super.HiJump),
+            CaseWith(x => x.Glove.Lamp.Morph.Super.SpringBall),
+            CaseWith(x => x.Glove.Lamp.Morph.Super.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.Morph.Wave.Ice),
+            CaseWith(x => x.Glove.Lamp.Morph.Wave.HiJump),
+            CaseWith(x => x.Glove.Lamp.Morph.Wave.SpringBall),
+            CaseWith(x => x.Glove.Lamp.Morph.Wave.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.Morph.Wave.Bombs),
+        };
+
+        protected override List<Case> PowerBombPinkBrinstar => new() {
+            CaseWith(x => x.Morph.PowerBomb.Super),
+        };
+
+        protected override List<Case> EnergyTankBrinstarGate => new() {
+            CaseWith(x => x.Morph.PowerBomb.Wave),
+            CaseWith(x => x.Morph.PowerBomb.Super),
+        };
+
+        #endregion
+
+        #region Brinstar Red
+
+        protected override List<Case> BrinstarRed => new() {
+            CaseWith(x => x.Morph.Bombs.Super),
+            CaseWith(x => x.Morph.PowerBomb.Super),
+            CaseWith(x => x.ScrewAttack.Super.Morph),
+            CaseWith(x => x.SpeedBooster.Super.Morph),
+            CaseWith(x => x.Flute.Ice),
+            CaseWith(x => x.Flute.Morph.SpringBall),
+            CaseWith(x => x.Flute.HiJump),
+            CaseWith(x => x.Flute.SpaceJump),
+            CaseWith(x => x.Flute.Morph.Bombs),
+            CaseWith(x => x.Glove.Lamp.Ice),
+            CaseWith(x => x.Glove.Lamp.Morph.SpringBall),
+            CaseWith(x => x.Glove.Lamp.HiJump),
+            CaseWith(x => x.Glove.Lamp.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.Morph.Bombs),
+        };
+
+        protected override List<Case> XRayScope => new() {
+            CaseWith(x => x.Morph.PowerBomb.Missile.Grapple),
+            CaseWith(x => x.Morph.PowerBomb.Missile.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Missile.Bombs.Varia.ETank(3)),
+            CaseWith(x => x.Morph.PowerBomb.Missile.Bombs.ETank(5)),
+            CaseWith(x => x.Morph.PowerBomb.Missile.HiJump.SpeedBooster.Varia.ETank(3)),
+            CaseWith(x => x.Morph.PowerBomb.Missile.HiJump.SpeedBooster.ETank(5)),
+            CaseWith(x => x.Morph.PowerBomb.Missile.SpringBall.Varia.ETank(3)),
+            CaseWith(x => x.Morph.PowerBomb.Missile.SpringBall.ETank(5)),
+            CaseWith(x => x.Morph.PowerBomb.Super.Grapple),
+            CaseWith(x => x.Morph.PowerBomb.Super.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Bombs.Varia.ETank(3)),
+            CaseWith(x => x.Morph.PowerBomb.Super.Bombs.ETank(5)),
+            CaseWith(x => x.Morph.PowerBomb.Super.HiJump.SpeedBooster.Varia.ETank(3)),
+            CaseWith(x => x.Morph.PowerBomb.Super.HiJump.SpeedBooster.ETank(5)),
+            CaseWith(x => x.Morph.PowerBomb.Super.SpringBall.Varia.ETank(3)),
+            CaseWith(x => x.Morph.PowerBomb.Super.SpringBall.ETank(5)),
+        };
+
+        protected override List<Case> PowerBombRedBrinstarSpikeRoom => new() {
+            CaseWith(x => x.Super),
+        };
+
+        #endregion
+
+        #region Maridia Outer
+
+        protected override List<Case> MaridiaOuter => new() {
+            CaseWith(x => x.Morph.PowerBomb.Super.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.Super.HiJump.SpringBall),
+            CaseWith(x => x.Morph.PowerBomb.Super.HiJump.Ice),
+            CaseWith(x => x.Flute.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Flute.Morph.PowerBomb.HiJump.SpringBall),
+            CaseWith(x => x.Flute.Morph.PowerBomb.HiJump.Ice),
+            CaseWith(x => x.Glove.Lamp.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Glove.Lamp.Morph.PowerBomb.HiJump.SpringBall),
+            CaseWith(x => x.Glove.Lamp.Morph.PowerBomb.HiJump.Ice),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Sword.Cape.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Sword.Cape.Lamp.KeyCT(2).PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.MasterSword.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.MasterSword.Lamp.KeyCT(2).PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Hammer.Glove.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Hammer.Glove.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Mitt.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Mitt.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).Super.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).Super.Ice),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).Super.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).Super.Ice),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.Super.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.Super.Ice),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.Super.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.Super.Ice),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Super),
+        };
+
+        protected override List<Case> MissileGreenMaridiaShinespark => new() {
+            CaseWith(x => x.Gravity.SpeedBooster),
+        };
+
+        protected override List<Case> EnergyTankMamaTurtle => new() {
+            CaseWith(x => x.Missile.SpaceJump),
+            CaseWith(x => x.Missile.Morph.Bombs),
+            CaseWith(x => x.Missile.SpeedBooster),
+            CaseWith(x => x.Missile.Grapple),
+            CaseWith(x => x.Missile.Morph.SpringBall.Gravity),
+            CaseWith(x => x.Missile.Morph.SpringBall.HiJump),
+            CaseWith(x => x.Super.SpaceJump),
+            CaseWith(x => x.Super.Morph.Bombs),
+            CaseWith(x => x.Super.SpeedBooster),
+            CaseWith(x => x.Super.Grapple),
+            CaseWith(x => x.Super.Morph.SpringBall.Gravity),
+            CaseWith(x => x.Super.Morph.SpringBall.HiJump),
+        };
+
+        #endregion
+
+        #region Maridia Inner
+
+        protected override List<Case> MaridiaInner => new() {
+            CaseWith(x => x.Super.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Super.Morph.PowerBomb.HiJump.Ice.Grapple),
+            CaseWith(x => x.Super.Morph.PowerBomb.HiJump.SpringBall.Grapple),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Mitt),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt),
+        };
+
+        protected override List<Case> YellowMaridiaWateringHole => new() {
+            CaseWith(x => x.Morph.Bombs.Gravity),
+            CaseWith(x => x.Morph.Bombs.Ice),
+            CaseWith(x => x.Morph.Bombs.HiJump.SpringBall),
+            CaseWith(x => x.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.Ice),
+            CaseWith(x => x.Morph.PowerBomb.HiJump.SpringBall),
+        };
+        protected override List<Case> MissileYellowMaridiaFalseWall => new() {
+            CaseWith(x => x.Morph.Bombs.Gravity),
+            CaseWith(x => x.Morph.Bombs.Ice),
+            CaseWith(x => x.Morph.Bombs.HiJump.SpringBall),
+            CaseWith(x => x.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.Ice),
+            CaseWith(x => x.Morph.PowerBomb.HiJump.SpringBall),
+        };
+
+        protected override List<Case> PlasmaBeam => new() {
+            CaseWith(x => x.Ice.Gravity.Charge.ETank(3).HiJump),
+            CaseWith(x => x.Ice.Gravity.Charge.ETank(3).Morph.SpringBall),
+            CaseWith(x => x.Ice.Gravity.Charge.ETank(3).SpaceJump),
+            CaseWith(x => x.Ice.Gravity.Charge.ETank(3).Morph.Bombs),
+            CaseWith(x => x.Ice.Gravity.ScrewAttack.HiJump),
+            CaseWith(x => x.Ice.Gravity.ScrewAttack.Morph.SpringBall),
+            CaseWith(x => x.Ice.Gravity.ScrewAttack.SpaceJump),
+            CaseWith(x => x.Ice.Gravity.ScrewAttack.Morph.Bombs),
+            CaseWith(x => x.Ice.Gravity.Plasma.HiJump),
+            CaseWith(x => x.Ice.Gravity.Plasma.Morph.SpringBall),
+            CaseWith(x => x.Ice.Gravity.Plasma.SpaceJump),
+            CaseWith(x => x.Ice.Gravity.Plasma.Morph.Bombs),
+            CaseWith(x => x.SpeedBooster.Gravity),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Charge.ETank(3).HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Charge.ETank(3).SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Charge.ETank(3).SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Charge.ETank(3).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).ScrewAttack.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).ScrewAttack.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).ScrewAttack.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).ScrewAttack.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Plasma.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Plasma.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Plasma.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Plasma.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Charge.ETank(3).HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Charge.ETank(3).SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Charge.ETank(3).SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Charge.ETank(3).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).ScrewAttack.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).ScrewAttack.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).ScrewAttack.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).ScrewAttack.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Plasma.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Plasma.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Plasma.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Plasma.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Charge.ETank(3).HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Charge.ETank(3).SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Charge.ETank(3).SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Charge.ETank(3).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.ScrewAttack.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.ScrewAttack.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.ScrewAttack.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.ScrewAttack.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Plasma.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Plasma.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Plasma.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Plasma.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Charge.ETank(3).HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Charge.ETank(3).SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Charge.ETank(3).SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Charge.ETank(3).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.ScrewAttack.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.ScrewAttack.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.ScrewAttack.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.ScrewAttack.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Plasma.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Plasma.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Plasma.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Plasma.Bombs),
+        };
+
+        protected override List<Case> LeftMaridiaSandPitRoom => new() {
+            CaseWith(x => x.Gravity.Super),
+            CaseWith(x => x.HiJump.Ice.Grapple.Super.SpaceJump),
+            CaseWith(x => x.HiJump.Morph.SpringBall.Grapple.Super),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Sword.Cape.Lamp.KeyCT(2).Super.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.MasterSword.Lamp.KeyCT(2).Super.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Hammer.Glove.Super.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Mitt.Super.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).Super.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).Super.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.Super.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.Super.SpaceJump),
+        };
+
+        protected override List<Case> MissileRightMaridiaSandPitRoom => new() {
+            CaseWith(x => x.Gravity.Super),
+            CaseWith(x => x.HiJump.Ice.Grapple.Super),
+            CaseWith(x => x.HiJump.Morph.SpringBall.Grapple.Super),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.Super),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.Super),
+        };
+
+        protected override List<Case> PowerBombRightMaridiaSandPitRoom => new() {
+            CaseWith(x => x.Gravity.Super),
+            CaseWith(x => x.HiJump.Morph.SpringBall.Grapple.Super),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Sword.Cape.Lamp.KeyCT(2).Super.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.MasterSword.Lamp.KeyCT(2).Super.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Hammer.Glove.Super.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Mitt.Super.HiJump),
+        };
+
+        protected override List<Case> PinkMaridia => new() {
+            CaseWith(x => x.Gravity),
+        };
+
+        protected override List<Case> SpringBall => new() {
+            CaseWith(x => x.Super.Grapple.Morph.PowerBomb.Gravity.SpaceJump),
+            CaseWith(x => x.Super.Grapple.Morph.PowerBomb.Gravity.Bombs),
+            CaseWith(x => x.Super.Grapple.Morph.PowerBomb.Gravity.HiJump),
+            CaseWith(x => x.Super.Grapple.Morph.PowerBomb.Ice.HiJump.SpringBall.SpaceJump),
+        };
+
+        protected override List<Case> MissileDraygon => new() {
+            CaseWith(x => x.Ice.Gravity),
+            CaseWith(x => x.SpeedBooster.Gravity),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt),
+        };
+
+        protected override List<Case> EnergyTankBotwoon => new() {
+            CaseWith(x => x.Ice),
+            CaseWith(x => x.SpeedBooster.Gravity),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Mitt),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt),
+        };
+
+        protected override List<Case> SpaceJump => new() {
+            CaseWith(x => x.Ice.Gravity),
+            CaseWith(x => x.SpeedBooster.Gravity),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt),
+        };
+
+        #endregion
+
+        #region Norfair Upper West
+
+        protected override List<Case> MissileLavaRoom => new() {
+            CaseWith(x => x.Varia.Missile.SpaceJump.Morph),
+            CaseWith(x => x.Varia.Missile.Morph.Bombs),
+            CaseWith(x => x.Varia.Missile.HiJump.Morph),
+            CaseWith(x => x.Varia.Missile.SpeedBooster.Morph),
+            CaseWith(x => x.Varia.Missile.Morph.SpringBall),
+            CaseWith(x => x.Varia.Missile.Ice.Morph),
+            CaseWith(x => x.Varia.Super.SpaceJump.Morph),
+            CaseWith(x => x.Varia.Super.Morph.Bombs),
+            CaseWith(x => x.Varia.Super.HiJump.Morph),
+            CaseWith(x => x.Varia.Super.SpeedBooster.Morph),
+            CaseWith(x => x.Varia.Super.Morph.SpringBall),
+            CaseWith(x => x.Varia.Super.Ice.Morph),
+            CaseWith(x => x.Varia.Flute.SpeedBooster.Morph.PowerBomb),
+            CaseWith(x => x.Varia.Glove.Lamp.SpeedBooster.Morph.PowerBomb),
+            CaseWith(x => x.ETank(5).Missile.SpaceJump.Morph),
+            CaseWith(x => x.ETank(5).Missile.Morph.Bombs),
+            CaseWith(x => x.ETank(5).Missile.HiJump.Morph),
+            CaseWith(x => x.ETank(5).Missile.SpeedBooster.Morph),
+            CaseWith(x => x.ETank(5).Missile.Morph.SpringBall),
+            CaseWith(x => x.ETank(5).Super.SpaceJump.Morph),
+            CaseWith(x => x.ETank(5).Super.Morph.Bombs),
+            CaseWith(x => x.ETank(5).Super.HiJump.Morph),
+            CaseWith(x => x.ETank(5).Super.SpeedBooster.Morph),
+            CaseWith(x => x.ETank(5).Super.Morph.SpringBall),
+            CaseWith(x => x.ETank(5).Flute.SpeedBooster.Morph.PowerBomb),
+            CaseWith(x => x.ETank(5).Glove.Lamp.SpeedBooster.Morph.PowerBomb),
+        };
+
+        protected override List<Case> IceBeam => new() {
+            CaseWith(x => x.Super.Morph.Varia),
+            CaseWith(x => x.Super.Morph.ETank(3)),
+        };
+
+        protected override List<Case> MissileBelowIceBeam => new() {
+            CaseWith(x => x.Super.Morph.PowerBomb.Varia),
+            CaseWith(x => x.Super.Morph.PowerBomb.ETank(3)),
+            CaseWith(x => x.Super.Varia.SpeedBooster),
+        };
+
+        #endregion
+
+        #region Norfair Upper East
+
+        protected override List<Case> NorfairUpperEast => new() {
+            CaseWith(x => x.Morph.Bombs.Super.Varia),
+            CaseWith(x => x.Morph.Bombs.Super.ETank(5)),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.SpringBall),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.Ice),
+            CaseWith(x => x.Morph.PowerBomb.Super.ETank(5).SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.ETank(5).HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.ETank(5).SpringBall),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.SpaceJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.HiJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.SpringBall),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.Ice),
+            CaseWith(x => x.ScrewAttack.Super.Morph.ETank(5).SpaceJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.ETank(5).HiJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.ETank(5).SpringBall),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Varia),
+            CaseWith(x => x.SpeedBooster.Super.Morph.ETank(5)),
+            CaseWith(x => x.Flute.Varia.Super.SpaceJump),
+            CaseWith(x => x.Flute.Varia.Super.HiJump),
+            CaseWith(x => x.Flute.Varia.Super.SpeedBooster),
+            CaseWith(x => x.Flute.Varia.Super.Morph.SpringBall),
+            CaseWith(x => x.Flute.Varia.Super.Ice),
+            CaseWith(x => x.Flute.Varia.SpeedBooster.Morph.PowerBomb),
+            CaseWith(x => x.Flute.ETank(5).Super.SpaceJump),
+            CaseWith(x => x.Flute.ETank(5).Super.HiJump),
+            CaseWith(x => x.Flute.ETank(5).Super.SpeedBooster),
+            CaseWith(x => x.Flute.ETank(5).Super.Morph.SpringBall),
+            CaseWith(x => x.Flute.ETank(5).SpeedBooster.Morph.PowerBomb),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.HiJump),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.SpeedBooster),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.Morph.SpringBall),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.Ice),
+            CaseWith(x => x.Glove.Lamp.Varia.SpeedBooster.Morph.PowerBomb),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Super.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Super.HiJump),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Super.SpeedBooster),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Super.Morph.SpringBall),
+            CaseWith(x => x.Glove.Lamp.ETank(5).SpeedBooster.Morph.PowerBomb),
+        };
+
+        protected override List<Case> ReserveTankNorfair => new() {
+            CaseWith(x => x.Morph.Super),
+        };
+        protected override List<Case> MissileNorfairReserveTank => new() {
+            CaseWith(x => x.Morph.Super),
+        };
+
+        protected override List<Case> MissileBubbleNorfairGreenDoor => new() {
+            CaseWith(x => x.Super),
+        };
+        protected override List<Case> MissileSpeedBooster => new() {
+            CaseWith(x => x.Super),
+        };
+        protected override List<Case> SpeedBooster => new() {
+            CaseWith(x => x.Super),
+        };
+
+        protected override List<Case> MissileWaveBeam => CaseWithNothing;
+
+        protected override List<Case> WaveBeam => new() {
+            CaseWith(x => x.Missile.Morph),
+            CaseWith(x => x.Missile.Grapple),
+            CaseWith(x => x.Missile.Varia.HiJump),
+            CaseWith(x => x.Missile.SpaceJump),
+            CaseWith(x => x.Super.Morph),
+            CaseWith(x => x.Super.Grapple),
+            CaseWith(x => x.Super.Varia.HiJump),
+            CaseWith(x => x.Super.SpaceJump),
+        };
+
+        #endregion
+
+        #region Norfair Upper Crocomire
+
+        protected override List<Case> NorfairUpperCrocomire => new() {
+            CaseWith(x => x.Morph.Bombs.Super.Varia),
+            CaseWith(x => x.Morph.Bombs.Super.ETank(5)),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.SpringBall),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.Ice),
+            CaseWith(x => x.Morph.PowerBomb.Super.ETank(5).SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.ETank(5).HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.ETank(5).SpringBall),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.SpaceJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.HiJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.SpringBall),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.Ice),
+            CaseWith(x => x.SpeedBooster.Super.Morph.ETank(2)),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Varia),
+            CaseWith(x => x.Flute.SpeedBooster.ETank(2).Missile),
+            CaseWith(x => x.Flute.SpeedBooster.ETank(2).Super),
+            CaseWith(x => x.Flute.SpeedBooster.ETank(2).Wave),
+            CaseWith(x => x.Flute.SpeedBooster.Varia.Missile),
+            CaseWith(x => x.Flute.SpeedBooster.Varia.Super),
+            CaseWith(x => x.Flute.SpeedBooster.Varia.Wave),
+            CaseWith(x => x.Flute.Varia.Super.SpaceJump.Morph),
+            CaseWith(x => x.Flute.Varia.Super.HiJump.Morph),
+            CaseWith(x => x.Flute.Varia.Super.Morph.SpringBall),
+            CaseWith(x => x.Flute.Varia.Super.Ice.Morph),
+            CaseWith(x => x.Glove.Lamp.SpeedBooster.ETank(2).Missile),
+            CaseWith(x => x.Glove.Lamp.SpeedBooster.ETank(2).Super),
+            CaseWith(x => x.Glove.Lamp.SpeedBooster.ETank(2).Wave),
+            CaseWith(x => x.Glove.Lamp.SpeedBooster.Varia.Missile),
+            CaseWith(x => x.Glove.Lamp.SpeedBooster.Varia.Super),
+            CaseWith(x => x.Glove.Lamp.SpeedBooster.Varia.Wave),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.SpaceJump.Morph),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.HiJump.Morph),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.Morph.SpringBall),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.Ice.Morph),
+            CaseWith(x => x.Varia.Flute.Mitt.ScrewAttack.SpaceJump.Super.ETank(2)),
+        };
+
+        protected override List<Case> EnergyTankCrocomire => new() {
+            CaseWith(x => x.Super),
+        };
+
+        protected override List<Case> MissileAboveCrocomire => new() {
+            CaseWith(x => x.SpaceJump.Varia),
+            CaseWith(x => x.SpaceJump.ETank(5)),
+            CaseWith(x => x.Morph.Bombs.Varia),
+            CaseWith(x => x.Morph.Bombs.ETank(5)),
+            CaseWith(x => x.Grapple.Varia),
+            CaseWith(x => x.Grapple.ETank(5)),
+            CaseWith(x => x.HiJump.SpeedBooster.Varia),
+            CaseWith(x => x.HiJump.SpeedBooster.ETank(5)),
+            CaseWith(x => x.HiJump.Morph.SpringBall.Varia),
+            CaseWith(x => x.HiJump.Morph.SpringBall.ETank(5)),
+            CaseWith(x => x.HiJump.Varia.Ice),
+        };
+
+        protected override List<Case> PowerBombCrocomire => new() {
+            CaseWith(x => x.Super),
+        };
+
+        protected override List<Case> MissileGrapplingBeam => new() {
+            CaseWith(x => x.Super.SpeedBooster),
+            CaseWith(x => x.Super.Morph.SpaceJump),
+            CaseWith(x => x.Super.Morph.Bombs),
+            CaseWith(x => x.Super.Morph.Grapple),
+        };
+
+        protected override List<Case> GrapplingBeam => new() {
+            CaseWith(x => x.Super.SpaceJump),
+            CaseWith(x => x.Super.Morph),
+            CaseWith(x => x.Super.Grapple),
+            CaseWith(x => x.Super.HiJump.SpeedBooster),
+        };
+
+        #endregion
+
+        #region Norfair Lower West
+
+        protected override List<Case> NorfairLowerWest => new() {
+            CaseWith(x => x.Morph.Bombs.Super.Varia.PowerBomb.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.SpaceJump.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.SpringBall.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.Ice.Gravity),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Varia.PowerBomb.Gravity),
+            CaseWith(x => x.Flute.Varia.SpeedBooster.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Flute.Varia.SpeedBooster.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Glove.Lamp.Varia.SpeedBooster.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Glove.Lamp.Varia.SpeedBooster.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Flute.Mitt.Morph.Bombs),
+            CaseWith(x => x.Flute.Mitt.Morph.PowerBomb),
+            CaseWith(x => x.Flute.Mitt.ScrewAttack),
+        };
+
+        protected override List<Case> MissileGoldTorizo => new() {
+            CaseWith(x => x.Morph.PowerBomb.SpaceJump.Varia.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.SpaceJump.Varia.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.SpaceJump.Varia.Flute.Mitt.Super),
+        };
+
+        protected override List<Case> SuperMissileGoldTorizo => new() {
+            CaseWith(x => x.Morph.Bombs.Varia.Super),
+            CaseWith(x => x.Morph.Bombs.Varia.Charge),
+            CaseWith(x => x.Morph.PowerBomb.Varia.Super),
+            CaseWith(x => x.Morph.PowerBomb.Varia.Charge),
+            CaseWith(x => x.ScrewAttack.Varia.Super),
+            CaseWith(x => x.ScrewAttack.Varia.Charge),
+        };
+
+        protected override List<Case> ScrewAttack => new() {
+            CaseWith(x => x.Morph.Bombs.Flute.Mitt),
+            CaseWith(x => x.Morph.Bombs.Varia),
+            CaseWith(x => x.Morph.PowerBomb.Flute.Mitt),
+            CaseWith(x => x.Morph.PowerBomb.Varia),
+            CaseWith(x => x.ScrewAttack.Flute.Mitt),
+            CaseWith(x => x.ScrewAttack.Varia),
+        };
+
+        protected override List<Case> MissileMickeyMouseRoom => new() {
+            CaseWith(x => x.Varia.Morph.Super.SpaceJump.PowerBomb),
+            CaseWith(x => x.Varia.Morph.Super.SpaceJump.ScrewAttack),
+            CaseWith(x => x.Varia.Morph.Super.Bombs),
+            CaseWith(x => x.Varia.Morph.Super.HiJump.PowerBomb),
+            CaseWith(x => x.Varia.Morph.Super.SpringBall.PowerBomb),
+            CaseWith(x => x.Varia.Morph.Super.Ice.Charge.PowerBomb),
+        };
+
+        #endregion
+
+        #region Norfair Lower East
+
+        protected override List<Case> NorfairLowerEast => new() {
+            CaseWith(x => x.Varia.Morph.Bombs.Super.PowerBomb.Gravity),
+            CaseWith(x => x.Varia.Morph.PowerBomb.Super.SpaceJump.Gravity),
+            CaseWith(x => x.Varia.Morph.PowerBomb.Super.HiJump),
+            CaseWith(x => x.Varia.Morph.PowerBomb.Super.SpringBall.Gravity),
+            CaseWith(x => x.Varia.Morph.PowerBomb.Super.Ice.Gravity.Charge),
+            CaseWith(x => x.Varia.Flute.SpeedBooster.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Varia.Flute.SpeedBooster.Morph.PowerBomb.Gravity.SpaceJump),
+            CaseWith(x => x.Varia.Flute.SpeedBooster.Morph.PowerBomb.Gravity.Bombs),
+            CaseWith(x => x.Varia.Flute.SpeedBooster.Morph.PowerBomb.Gravity.SpringBall),
+            CaseWith(x => x.Varia.Flute.SpeedBooster.Morph.PowerBomb.Gravity.Ice.Charge),
+            CaseWith(x => x.Varia.Glove.Lamp.SpeedBooster.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Varia.Glove.Lamp.SpeedBooster.Morph.PowerBomb.Gravity.SpaceJump),
+            CaseWith(x => x.Varia.Glove.Lamp.SpeedBooster.Morph.PowerBomb.Gravity.Bombs),
+            CaseWith(x => x.Varia.Glove.Lamp.SpeedBooster.Morph.PowerBomb.Gravity.SpringBall),
+            CaseWith(x => x.Varia.Glove.Lamp.SpeedBooster.Morph.PowerBomb.Gravity.Ice.Charge),
+            CaseWith(x => x.Varia.Flute.Mitt.Morph.Bombs.Super),
+            CaseWith(x => x.Varia.Flute.Mitt.Morph.PowerBomb.Super.SpaceJump),
+            CaseWith(x => x.Varia.Flute.Mitt.Morph.PowerBomb.Super.SpringBall),
+            CaseWith(x => x.Varia.Flute.Mitt.Morph.PowerBomb.Super.SpeedBooster.Ice.Charge),
+            CaseWith(x => x.Varia.Flute.Mitt.ScrewAttack.Super.SpaceJump),
+        };
+
+        protected override List<Case> MissileLowerNorfairAboveFireFleaRoom => new() {
+            CaseWith(x => x.Morph),
+            CaseWith(x => x.ETank(5)),
+        };
+
+        protected override List<Case> PowerBombLowerNorfairAboveFireFleaRoom => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        protected override List<Case> MissileLowerNorfairNearWaveBeam => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+            CaseWith(x => x.Morph.ScrewAttack),
+        };
+
+        protected override List<Case> EnergyTankFirefleas => new() {
+            CaseWith(x => x.Morph),
+            CaseWith(x => x.ETank(5)),
+        };
+
+        #endregion
+
+        #region Light World North West
+
+        protected override List<Case> GraveyardLedge => new() {
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> KingsTomb => new() {
+            CaseWith(x => x.Boots.Mitt),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Hammer.Glove),
+        };
+
+        #endregion
+
+        #region Light World South
+
+        protected override List<Case> SouthOfGrove => new() {
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> CheckerboardCave => new() {
+            CaseWith(x => x.Mirror.Flute.Mitt),
+            CaseWith(x => x.Mirror.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Glove),
+            CaseWith(x => x.Mirror.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Glove),
+            CaseWith(x => x.Mirror.Varia.Super.HiJump.Morph.PowerBomb.Glove),
+            CaseWith(x => x.Mirror.Varia.Super.SpeedBooster.Gravity.Morph.PowerBomb.Glove),
+            CaseWith(x => x.Mirror.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Glove),
+            CaseWith(x => x.Mirror.Varia.Super.Ice.Gravity.Morph.PowerBomb.Glove),
+        };
+
+        protected override List<Case> BombosTablet => new() {
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> LakeHyliaIsland => new() {
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Hammer.Glove),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Mitt),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Morph.PowerBomb.Super.Charge.Gravity.Ice),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Morph.PowerBomb.Super.Missile.Gravity.Ice),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple),
+        };
+
+        #endregion
+
+        #region Dark World North West
+
+        protected override List<Case> DarkWorldNorthWest => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        #endregion
+
+        #region Dark World North East
+
+        protected override List<Case> DarkWorldNorthEast => new() {
+            CaseWith(x => x.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers),
+        };
+
+        protected override List<Case> PyramidFairy => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers.Mirror),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove.Mirror),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers.Mirror),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove.Mirror),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt.Mirror.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Mitt.Mirror.MasterSword.Lamp.KeyCT(2)),
+        };
+
+        #endregion
+
+        #region Dark World South
+
+        protected override List<Case> DarkWorldSouth => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        #endregion
+
+        #region Dark World Mire
+
+        protected override List<Case> DarkWorldMire => new() {
+            CaseWith(x => x.Flute.Mitt),
+            CaseWith(x => x.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.Varia.Super.Morph.Bombs.Gravity.PowerBomb),
+            CaseWith(x => x.Varia.Super.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.Varia.Super.SpeedBooster.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.Varia.Super.Morph.SpringBall.Gravity.PowerBomb),
+            CaseWith(x => x.Varia.Super.Ice.Gravity.Morph.PowerBomb),
+        };
+
+        #endregion
+
+        #region Desert Palace
+
+        protected override List<Case> DesertPalace => new() {
+            CaseWith(x => x.Book),
+            CaseWith(x => x.Mirror.Mitt.Flute),
+            CaseWith(x => x.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror),
+            CaseWith(x => x.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror),
+            CaseWith(x => x.Varia.Super.HiJump.Morph.PowerBomb.Mirror),
+            CaseWith(x => x.Varia.Super.SpeedBooster.Gravity.Morph.PowerBomb.Mirror),
+            CaseWith(x => x.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror),
+            CaseWith(x => x.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror),
+        };
+
+        protected override List<Case> DesertPalaceLanmolas => new() {
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Firerod),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Lamp.Sword),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Lamp.Hammer),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Lamp.Bow),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Lamp.Icerod),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Lamp.Byrna),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Lamp.Somaria),
+            CaseWith(x => x.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Firerod),
+            CaseWith(x => x.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Sword),
+            CaseWith(x => x.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Hammer),
+            CaseWith(x => x.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Bow),
+            CaseWith(x => x.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Icerod),
+            CaseWith(x => x.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Byrna),
+            CaseWith(x => x.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Somaria),
+            CaseWith(x => x.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Firerod),
+            CaseWith(x => x.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Sword),
+            CaseWith(x => x.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Hammer),
+            CaseWith(x => x.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Bow),
+            CaseWith(x => x.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Icerod),
+            CaseWith(x => x.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Byrna),
+            CaseWith(x => x.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Somaria),
+            CaseWith(x => x.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Firerod),
+            CaseWith(x => x.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Sword),
+            CaseWith(x => x.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Hammer),
+            CaseWith(x => x.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Bow),
+            CaseWith(x => x.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Icerod),
+            CaseWith(x => x.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Byrna),
+            CaseWith(x => x.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Somaria),
+            CaseWith(x => x.Varia.Super.SpeedBooster.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Firerod),
+            CaseWith(x => x.Varia.Super.SpeedBooster.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Sword),
+            CaseWith(x => x.Varia.Super.SpeedBooster.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Hammer),
+            CaseWith(x => x.Varia.Super.SpeedBooster.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Bow),
+            CaseWith(x => x.Varia.Super.SpeedBooster.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Icerod),
+            CaseWith(x => x.Varia.Super.SpeedBooster.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Byrna),
+            CaseWith(x => x.Varia.Super.SpeedBooster.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Somaria),
+            CaseWith(x => x.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Firerod),
+            CaseWith(x => x.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Sword),
+            CaseWith(x => x.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Hammer),
+            CaseWith(x => x.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Bow),
+            CaseWith(x => x.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Icerod),
+            CaseWith(x => x.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Byrna),
+            CaseWith(x => x.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Somaria),
+            CaseWith(x => x.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Firerod),
+            CaseWith(x => x.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Sword),
+            CaseWith(x => x.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Hammer),
+            CaseWith(x => x.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Bow),
+            CaseWith(x => x.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Icerod),
+            CaseWith(x => x.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Byrna),
+            CaseWith(x => x.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Somaria),
+        };
+
+        #endregion
+
+        #region Palace of Darkness
+
+        protected override List<Case> PalaceOfDarkness => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers),
+        };
+
+        #endregion
+
+        #region Swamp Palace
+
+        protected override List<Case> SwampPalace => new() {
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Sword.Cape.Lamp.KeyCT(2).Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.MasterSword.Lamp.KeyCT(2).Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Charge.Gravity.Ice.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Charge.Gravity.Ice.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Missile.Gravity.Ice.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Missile.Gravity.Ice.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Mitt),
+        };
+
+        #endregion
+
+        #region Skull Woods
+
+        protected override List<Case> SkullWoods => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        #endregion
+
+        #region Thieves' Town
+
+        protected override List<Case> ThievesTown => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        #endregion
+
+        #region Misery Mire
+
+        protected override List<Case> MiseryMire => new() {
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.Flute.Mitt),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.Varia.Super.Morph.Bombs.Gravity.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.Varia.Super.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.Varia.Super.SpeedBooster.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.Varia.Super.Morph.SpringBall.Gravity.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.Varia.Super.Ice.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.Flute.Mitt),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.Varia.Super.Morph.Bombs.Gravity.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.Varia.Super.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.Varia.Super.SpeedBooster.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.Varia.Super.Morph.SpringBall.Gravity.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.Varia.Super.Ice.Gravity.Morph.PowerBomb),
+        };
+
+        #endregion
+
+    }
+
+}

--- a/Randomizer.SMZ3.Tests/Logic/SMHardKeysanity.cs
+++ b/Randomizer.SMZ3.Tests/Logic/SMHardKeysanity.cs
@@ -1,0 +1,1387 @@
+﻿using System.Collections.Generic;
+
+namespace Randomizer.SMZ3.Tests.Logic {
+
+    public class SMHardKeysanity : SMHard {
+
+        #region Crateria West
+
+        protected override List<Case> EnergyTankGauntlet => new() {
+            CaseWith(x => x.CardCrateriaL1.Morph.Bombs),
+            CaseWith(x => x.CardCrateriaL1.Morph.TwoPowerBombs),
+            CaseWith(x => x.CardCrateriaL1.ScrewAttack),
+            CaseWith(x => x.CardCrateriaL1.SpeedBooster.Morph.PowerBomb.ETank(2)),
+        };
+
+        protected override List<Case> MissileCrateriaGauntlet => new() {
+            CaseWith(x => x.CardCrateriaL1.Morph.Bombs),
+            CaseWith(x => x.CardCrateriaL1.Morph.TwoPowerBombs),
+            CaseWith(x => x.CardCrateriaL1.ScrewAttack.Morph.PowerBomb),
+            CaseWith(x => x.CardCrateriaL1.SpeedBooster.Morph.PowerBomb.ETank(2)),
+        };
+
+        #endregion
+
+        #region Crateria Central
+
+        protected override List<Case> PowerBombCrateriaSurface => new() {
+            CaseWith(x => x.CardCrateriaL1.SpeedBooster),
+            CaseWith(x => x.CardCrateriaL1.SpaceJump),
+            CaseWith(x => x.CardCrateriaL1.Morph.Bombs),
+        };
+
+        protected override List<Case> Bombs => new() {
+            CaseWith(x => x.CardCrateriaBoss.Morph),
+        };
+
+        #endregion
+
+        #region Crateria East
+
+        protected override List<Case> CrateriaEast => new() {
+            CaseWith(x => x.CardCrateriaL2.Super),
+            CaseWith(x => x.CardCrateriaL2.Flute.Ice),
+            CaseWith(x => x.CardCrateriaL2.Flute.HiJump),
+            CaseWith(x => x.CardCrateriaL2.Flute.SpaceJump),
+            CaseWith(x => x.CardCrateriaL2.Flute.Morph.Bombs),
+            CaseWith(x => x.CardCrateriaL2.Flute.Morph.SpringBall),
+            CaseWith(x => x.CardCrateriaL2.Glove.Lamp.Ice),
+            CaseWith(x => x.CardCrateriaL2.Glove.Lamp.HiJump),
+            CaseWith(x => x.CardCrateriaL2.Glove.Lamp.SpaceJump),
+            CaseWith(x => x.CardCrateriaL2.Glove.Lamp.Morph.Bombs),
+            CaseWith(x => x.CardCrateriaL2.Glove.Lamp.Morph.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL2.Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL2.Super.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL2.Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL2.Super.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.CardMaridiaL2.Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.CardMaridiaL2.Super.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.CardMaridiaL2.Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.CardMaridiaL2.Super.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL2.Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL2.Super.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL2.Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL2.Super.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaL2.Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaL2.Super.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaL2.Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaL2.Super.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss),
+            CaseWith(x => x.Morph.PowerBomb.Super.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.Super.HiJump.Ice.Grapple.CardMaridiaL1),
+            CaseWith(x => x.Morph.PowerBomb.Super.HiJump.SpringBall.Grapple.CardMaridiaL1),
+        };
+
+        protected override List<Case> MissilesOutsideWreckedShipTopHalf => new() {
+            CaseWith(x => x.Super.CardCrateriaL2.CardWreckedShipBoss.Morph.Bombs),
+            CaseWith(x => x.Super.CardCrateriaL2.CardWreckedShipBoss.Morph.PowerBomb),
+            CaseWith(x => x.Super.Morph.PowerBomb.Gravity.CardWreckedShipBoss),
+            CaseWith(x => x.Super.Morph.PowerBomb.HiJump.Ice.Grapple.CardMaridiaL1.CardWreckedShipBoss),
+            CaseWith(x => x.Super.Morph.PowerBomb.HiJump.Morph.SpringBall.Grapple.CardMaridiaL1.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).PowerBomb.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).Bombs.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).PowerBomb.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.Bombs.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.PowerBomb.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Mitt.Bombs.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Mitt.PowerBomb.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.CardWreckedShipBoss.Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Bombs.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.CardWreckedShipBoss.Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Bombs.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.CardWreckedShipBoss.Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.Bombs.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.CardWreckedShipBoss.Bombs),
+        };
+
+        #endregion
+
+        #region Wrecked Ship
+
+        protected override List<Case> WreckedShip => new() {
+            CaseWith(x => x.Super.CardCrateriaL2),
+            CaseWith(x => x.Super.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Super.Morph.PowerBomb.HiJump.Ice.Grapple.CardMaridiaL1),
+            CaseWith(x => x.Super.Morph.PowerBomb.HiJump.Morph.SpringBall.Grapple.CardMaridiaL1),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).PowerBomb.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).Bombs.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).PowerBomb.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.Bombs.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.PowerBomb.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Mitt.Bombs.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.HiJump.Morph.Mitt.PowerBomb.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).ScrewAttack.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Bombs.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).ScrewAttack.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Bombs.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.ScrewAttack.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.Bombs.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.ScrewAttack.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss),
+        };
+
+        protected override List<Case> ReserveTankWreckedShip => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.SpeedBooster.Varia),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.SpeedBooster.ETank(2)),
+        };
+
+        protected override List<Case> MissileGravitySuit => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.CardWreckedShipL1.Varia),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.CardWreckedShipL1.ETank(1)),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.Varia),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.ETank(1)),
+        };
+
+        protected override List<Case> MissileWreckedShipTop => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb),
+        };
+
+        protected override List<Case> EnergyTankWreckedShip => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb),
+        };
+
+        protected override List<Case> SuperMissileWreckedShipLeft => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb),
+        };
+
+        protected override List<Case> SuperMissileWreckedShipRight => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb),
+        };
+
+        protected override List<Case> GravitySuit => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.CardWreckedShipL1.Varia),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.CardWreckedShipL1.ETank(1)),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.Varia),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.ETank(1)),
+        };
+
+        #endregion
+
+        #region Brinstar Blue
+
+        protected override List<Case> MissileBlueBrinstarMiddle => new() {
+            CaseWith(x => x.CardBrinstarL1.Morph),
+        };
+        
+        protected override List<Case> EnergyTankBrinstarCeiling => new() {
+            CaseWith(x => x.CardBrinstarL1),
+        };
+
+        protected override List<Case> MissileBlueBrinstarBillyMays => new() {
+            CaseWith(x => x.CardBrinstarL1.Morph.PowerBomb),
+        };
+
+        #endregion
+
+        #region Brinstar Green
+
+        protected override List<Case> PowerBombGreenBrinstarBottom => new() {
+            CaseWith(x => x.CardBrinstarL2.Morph.PowerBomb),
+        };
+
+        protected override List<Case> EnergyTankEtecoons => new() {
+            CaseWith(x => x.CardBrinstarL2.Morph.PowerBomb),
+        };
+
+        protected override List<Case> SuperMissileGreenBrinstarBottom => new() {
+            CaseWith(x => x.CardBrinstarL2.Morph.PowerBomb.Super),
+        };
+
+        #endregion
+
+        #region Brinstar Pink
+
+        protected override List<Case> SuperMissilePinkBrinstar => new() {
+            CaseWith(x => x.CardBrinstarBoss.Morph.Bombs.Super),
+            CaseWith(x => x.CardBrinstarBoss.Morph.PowerBomb.Super),
+            CaseWith(x => x.CardBrinstarL2.Morph.Bombs.Super),
+            CaseWith(x => x.CardBrinstarL2.Morph.PowerBomb.Super),
+        };
+
+        protected override List<Case> EnergyTankBrinstarGate => new() {
+            CaseWith(x => x.CardBrinstarL2.Morph.PowerBomb.Wave),
+            CaseWith(x => x.CardBrinstarL2.Morph.PowerBomb.Super),
+        };
+
+        #endregion
+
+        #region Brinstar Kraid
+
+        protected override List<Case> EnergyTankKraid => new() {
+            CaseWith(x => x.CardBrinstarBoss),
+        };
+        protected override List<Case> VariaSuit => new() {
+            CaseWith(x => x.CardBrinstarBoss),
+        };
+
+        #endregion
+
+        #region Maridia Outer
+
+        protected override List<Case> MaridiaOuter => new() {
+            CaseWith(x => x.Morph.PowerBomb.Super.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.Super.HiJump.SpringBall),
+            CaseWith(x => x.Morph.PowerBomb.Super.HiJump.Ice),
+            CaseWith(x => x.Flute.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Flute.Morph.PowerBomb.HiJump.SpringBall),
+            CaseWith(x => x.Flute.Morph.PowerBomb.HiJump.Ice),
+            CaseWith(x => x.Glove.Lamp.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Glove.Lamp.Morph.PowerBomb.HiJump.SpringBall),
+            CaseWith(x => x.Glove.Lamp.Morph.PowerBomb.HiJump.Ice),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.MasterSword.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.MasterSword.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Hammer.Glove.CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Hammer.Glove.CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Mitt.CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Mitt.CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Super.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Super.Ice),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Super.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Super.Ice),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.CardMaridiaL1.CardMaridiaL2.Super.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.CardMaridiaL1.CardMaridiaL2.Super.Ice),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.CardMaridiaL1.CardMaridiaL2.Super.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.CardMaridiaL1.CardMaridiaL2.Super.Ice),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Super),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Super),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaL1.CardMaridiaL2.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaL1.CardMaridiaL2.Super),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaL1.CardMaridiaL2.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaL1.CardMaridiaL2.Super),
+        };
+
+        #endregion
+
+        #region Maridia Inner
+
+        protected override List<Case> YellowMaridiaWateringHole => new() {
+            CaseWith(x => x.CardMaridiaL1.Morph.Bombs.Gravity),
+            CaseWith(x => x.CardMaridiaL1.Morph.Bombs.Ice),
+            CaseWith(x => x.CardMaridiaL1.Morph.Bombs.HiJump.SpringBall),
+            CaseWith(x => x.CardMaridiaL1.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.CardMaridiaL1.Morph.PowerBomb.Ice),
+            CaseWith(x => x.CardMaridiaL1.Morph.PowerBomb.HiJump.SpringBall),
+        };
+        protected override List<Case> MissileYellowMaridiaFalseWall => new() {
+            CaseWith(x => x.CardMaridiaL1.Morph.Bombs.Gravity),
+            CaseWith(x => x.CardMaridiaL1.Morph.Bombs.Ice),
+            CaseWith(x => x.CardMaridiaL1.Morph.Bombs.HiJump.Morph.SpringBall),
+            CaseWith(x => x.CardMaridiaL1.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.CardMaridiaL1.Morph.PowerBomb.Ice),
+            CaseWith(x => x.CardMaridiaL1.Morph.PowerBomb.HiJump.Morph.SpringBall),
+        };
+
+        protected override List<Case> PlasmaBeam => new() {
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.CardMaridiaBoss.Gravity.Charge.ETank(3).HiJump),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.CardMaridiaBoss.Gravity.Charge.ETank(3).Morph.SpringBall),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.CardMaridiaBoss.Gravity.Charge.ETank(3).SpaceJump),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.CardMaridiaBoss.Gravity.Charge.ETank(3).Morph.Bombs),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.CardMaridiaBoss.Gravity.ScrewAttack.HiJump),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.CardMaridiaBoss.Gravity.ScrewAttack.Morph.SpringBall),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.CardMaridiaBoss.Gravity.ScrewAttack.SpaceJump),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.CardMaridiaBoss.Gravity.ScrewAttack.Morph.Bombs),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.CardMaridiaBoss.Gravity.Plasma.HiJump),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.CardMaridiaBoss.Gravity.Plasma.Morph.SpringBall),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.CardMaridiaBoss.Gravity.Plasma.SpaceJump),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.CardMaridiaBoss.Gravity.Plasma.Morph.Bombs),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster.Gravity.CardMaridiaBoss),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.Charge.ETank(3).HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.Charge.ETank(3).SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.Charge.ETank(3).SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.Charge.ETank(3).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.ScrewAttack.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.ScrewAttack.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.ScrewAttack.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.ScrewAttack.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.Plasma.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.Plasma.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.Plasma.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.Plasma.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.SpeedBooster),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.Charge.ETank(3).HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.Charge.ETank(3).SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.Charge.ETank(3).SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.Charge.ETank(3).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.ScrewAttack.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.ScrewAttack.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.ScrewAttack.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.ScrewAttack.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.Plasma.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.Plasma.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.Plasma.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.Plasma.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.SpeedBooster),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.Charge.ETank(3).HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.Charge.ETank(3).SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.Charge.ETank(3).SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.Charge.ETank(3).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.ScrewAttack.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.ScrewAttack.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.ScrewAttack.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.ScrewAttack.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.Plasma.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.Plasma.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.Plasma.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.Plasma.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.SpeedBooster),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.Charge.ETank(3).HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.Charge.ETank(3).SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.Charge.ETank(3).SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.Charge.ETank(3).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.ScrewAttack.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.ScrewAttack.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.ScrewAttack.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.ScrewAttack.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.Plasma.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.Plasma.SpringBall),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.Plasma.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.Plasma.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.SpeedBooster),
+        };
+
+        protected override List<Case> LeftMaridiaSandPitRoom => new() {
+            CaseWith(x => x.CardMaridiaL1.Gravity.Super),
+            CaseWith(x => x.CardMaridiaL1.HiJump.Ice.Grapple.Super.SpaceJump),
+            CaseWith(x => x.CardMaridiaL1.HiJump.Morph.SpringBall.Grapple.Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Morph.SpringBall.Sword.Cape.Lamp.KeyCT(2).Super.HiJump),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Morph.SpringBall.MasterSword.Lamp.KeyCT(2).Super.HiJump),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Morph.SpringBall.Hammer.Glove.Super.HiJump),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Morph.SpringBall.Mitt.Super.HiJump),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).Super.SpaceJump),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).Super.SpaceJump),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.Super.SpaceJump),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.HiJump.Morph.Mitt.Super.SpaceJump),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Mitt.Super),
+        };
+
+        protected override List<Case> MissileRightMaridiaSandPitRoom => new() {
+            CaseWith(x => x.CardMaridiaL1.Gravity.Super),
+            CaseWith(x => x.CardMaridiaL1.HiJump.Ice.Grapple.Super),
+            CaseWith(x => x.CardMaridiaL1.HiJump.Morph.SpringBall.Grapple.Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.HiJump.Morph.Mitt.Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Mitt.Super),
+        };
+
+        protected override List<Case> PowerBombRightMaridiaSandPitRoom => new() {
+            CaseWith(x => x.CardMaridiaL1.Gravity.Super),
+            CaseWith(x => x.CardMaridiaL1.HiJump.Morph.SpringBall.Grapple.Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Morph.SpringBall.Sword.Cape.Lamp.KeyCT(2).Super.HiJump),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Morph.SpringBall.MasterSword.Lamp.KeyCT(2).Super.HiJump),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Morph.SpringBall.Hammer.Glove.Super.HiJump),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Morph.SpringBall.Mitt.Super.HiJump),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Mitt.Super),
+        };
+
+        protected override List<Case> PinkMaridia => new() {
+            CaseWith(x => x.CardMaridiaL1.Gravity),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Gravity),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Gravity),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Gravity),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Mitt.Gravity),
+        };
+
+
+        protected override List<Case> MissileDraygon => new() {
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.Gravity),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster.Gravity),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt),
+        };
+
+        protected override List<Case> EnergyTankBotwoon => new() {
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster.Gravity),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.MasterSword.Lamp.KeyCT(2).CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Hammer.Glove.CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.Morph.SpringBall.Mitt.CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Hammer.Glove.CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.HiJump.Morph.Mitt.CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaL2),
+        };
+
+        protected override List<Case> SpaceJump => new() {
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.Ice.CardMaridiaBoss.Gravity),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster.Gravity.CardMaridiaBoss),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss),
+        };
+
+        #endregion
+
+        #region Norfair Upper West
+
+        protected override List<Case> MissileLavaRoom => new() {
+            CaseWith(x => x.Varia.Missile.SpaceJump.Morph),
+            CaseWith(x => x.Varia.Missile.Morph.Bombs),
+            CaseWith(x => x.Varia.Missile.HiJump.Morph),
+            CaseWith(x => x.Varia.Missile.SpeedBooster.Morph),
+            CaseWith(x => x.Varia.Missile.Morph.SpringBall),
+            CaseWith(x => x.Varia.Missile.Ice.Morph),
+            CaseWith(x => x.Varia.Super.SpaceJump.Morph),
+            CaseWith(x => x.Varia.Super.Morph.Bombs),
+            CaseWith(x => x.Varia.Super.HiJump.Morph),
+            CaseWith(x => x.Varia.Super.SpeedBooster.Morph),
+            CaseWith(x => x.Varia.Super.Morph.SpringBall),
+            CaseWith(x => x.Varia.Super.Ice.Morph),
+            CaseWith(x => x.Varia.Flute.SpeedBooster.CardNorfairL2.Morph.PowerBomb),
+            CaseWith(x => x.Varia.Glove.Lamp.SpeedBooster.CardNorfairL2.Morph.PowerBomb),
+            CaseWith(x => x.ETank(5).Missile.SpaceJump.Morph),
+            CaseWith(x => x.ETank(5).Missile.Morph.Bombs),
+            CaseWith(x => x.ETank(5).Missile.HiJump.Morph),
+            CaseWith(x => x.ETank(5).Missile.SpeedBooster.Morph),
+            CaseWith(x => x.ETank(5).Missile.Morph.SpringBall),
+            CaseWith(x => x.ETank(5).Super.SpaceJump.Morph),
+            CaseWith(x => x.ETank(5).Super.Morph.Bombs),
+            CaseWith(x => x.ETank(5).Super.HiJump.Morph),
+            CaseWith(x => x.ETank(5).Super.SpeedBooster.Morph),
+            CaseWith(x => x.ETank(5).Super.Morph.SpringBall),
+            CaseWith(x => x.ETank(5).Flute.SpeedBooster.CardNorfairL2.Morph.PowerBomb),
+            CaseWith(x => x.ETank(5).Glove.Lamp.SpeedBooster.CardNorfairL2.Morph.PowerBomb),
+        };
+
+        protected override List<Case> IceBeam => new() {
+            CaseWith(x => x.CardNorfairL1.Morph.Varia),
+            CaseWith(x => x.CardNorfairL1.Morph.ETank(3)),
+        };
+        
+        protected override List<Case> MissileBelowIceBeam => new() {
+            CaseWith(x => x.CardNorfairL1.Morph.PowerBomb.Varia),
+            CaseWith(x => x.CardNorfairL1.Morph.PowerBomb.ETank(3)),
+            CaseWith(x => x.Missile.Varia.SpeedBooster.CardNorfairBoss.CardNorfairL1),
+            CaseWith(x => x.Super.Varia.SpeedBooster.CardNorfairBoss.CardNorfairL1),
+            CaseWith(x => x.Wave.Varia.SpeedBooster.CardNorfairBoss.CardNorfairL1),
+        };
+
+        #endregion
+
+        #region Norfair Upper East
+
+        protected override List<Case> NorfairUpperEast => new() {
+            CaseWith(x => x.Morph.Bombs.Super.Varia.CardNorfairL2),
+            CaseWith(x => x.Morph.Bombs.Super.ETank(5).CardNorfairL2),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.SpringBall),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.Ice),
+            CaseWith(x => x.Morph.PowerBomb.Super.ETank(5).CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.ETank(5).CardNorfairL2.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.ETank(5).CardNorfairL2.SpringBall),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.CardNorfairL2.HiJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.CardNorfairL2.SpringBall),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.CardNorfairL2.Ice),
+            CaseWith(x => x.ScrewAttack.Super.Morph.ETank(5).CardNorfairL2.SpaceJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.ETank(5).CardNorfairL2.HiJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.ETank(5).CardNorfairL2.SpringBall),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Varia.CardNorfairL2),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Varia.PowerBomb),
+            CaseWith(x => x.SpeedBooster.Super.Morph.ETank(5).CardNorfairL2),
+            CaseWith(x => x.SpeedBooster.Super.Morph.ETank(5).PowerBomb),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.HiJump),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.SpeedBooster),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.Morph.SpringBall),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.Ice),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.HiJump),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.SpeedBooster),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.Morph.SpringBall),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.Ice),
+            CaseWith(x => x.Flute.Varia.SpeedBooster.CardNorfairL2.Morph.PowerBomb),
+            CaseWith(x => x.Flute.Varia.SpeedBooster.Missile.Morph.PowerBomb),
+            CaseWith(x => x.Flute.Varia.SpeedBooster.Wave.Morph.PowerBomb),
+            CaseWith(x => x.Flute.ETank(5).Missile.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Flute.ETank(5).Missile.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.Flute.ETank(5).Missile.CardNorfairL2.HiJump),
+            CaseWith(x => x.Flute.ETank(5).Missile.CardNorfairL2.SpeedBooster),
+            CaseWith(x => x.Flute.ETank(5).Missile.CardNorfairL2.Morph.SpringBall),
+            CaseWith(x => x.Flute.ETank(5).Super.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Flute.ETank(5).Super.CardNorfairL2.HiJump),
+            CaseWith(x => x.Flute.ETank(5).Super.CardNorfairL2.SpeedBooster),
+            CaseWith(x => x.Flute.ETank(5).Super.CardNorfairL2.Morph.SpringBall),
+            CaseWith(x => x.Flute.ETank(5).SpeedBooster.CardNorfairL2.Morph.PowerBomb),
+            CaseWith(x => x.Flute.ETank(5).SpeedBooster.Missile.Morph.PowerBomb),
+            CaseWith(x => x.Flute.ETank(5).SpeedBooster.Wave.Morph.PowerBomb),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.HiJump),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.SpeedBooster),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.Morph.SpringBall),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.Ice),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.HiJump),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.SpeedBooster),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.Morph.SpringBall),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.Ice),
+            CaseWith(x => x.Glove.Lamp.Varia.SpeedBooster.CardNorfairL2.Morph.PowerBomb),
+            CaseWith(x => x.Glove.Lamp.Varia.SpeedBooster.Missile.Morph.PowerBomb),
+            CaseWith(x => x.Glove.Lamp.Varia.SpeedBooster.Wave.Morph.PowerBomb),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Missile.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Missile.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Missile.CardNorfairL2.HiJump),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Missile.CardNorfairL2.SpeedBooster),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Missile.CardNorfairL2.Morph.SpringBall),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Super.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Super.CardNorfairL2.HiJump),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Super.CardNorfairL2.SpeedBooster),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Super.CardNorfairL2.Morph.SpringBall),
+            CaseWith(x => x.Glove.Lamp.ETank(5).SpeedBooster.CardNorfairL2.Morph.PowerBomb),
+            CaseWith(x => x.Glove.Lamp.ETank(5).SpeedBooster.Missile.Morph.PowerBomb),
+            CaseWith(x => x.Glove.Lamp.ETank(5).SpeedBooster.Wave.Morph.PowerBomb),
+        };
+
+        protected override List<Case> ReserveTankNorfair => new() {
+            CaseWith(x => x.CardNorfairL2.Morph.Super),
+        };
+        protected override List<Case> MissileNorfairReserveTank => new() {
+            CaseWith(x => x.CardNorfairL2.Morph.Super),
+        };
+        
+        protected override List<Case> MissileBubbleNorfairGreenDoor => new() {
+            CaseWith(x => x.CardNorfairL2.Super),
+        };
+
+        protected override List<Case> MissileBubbleNorfair => new() {
+            CaseWith(x => x.CardNorfairL2),
+        };
+
+        protected override List<Case> MissileSpeedBooster => new() {
+            CaseWith(x => x.CardNorfairL2.Super),
+        };
+        protected override List<Case> SpeedBooster => new() {
+            CaseWith(x => x.CardNorfairL2.Super),
+        };
+
+        protected override List<Case> MissileWaveBeam => new() {
+            CaseWith(x => x.CardNorfairL2),
+            CaseWith(x => x.Varia),
+        };
+
+        protected override List<Case> WaveBeam => new() {
+            CaseWith(x => x.Missile.CardNorfairL2.Morph),
+            CaseWith(x => x.Missile.CardNorfairL2.Grapple),
+            CaseWith(x => x.Missile.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Missile.Varia.Morph),
+            CaseWith(x => x.Missile.Varia.Grapple),
+            CaseWith(x => x.Missile.Varia.HiJump),
+            CaseWith(x => x.Missile.Varia.SpaceJump),
+            CaseWith(x => x.Super.CardNorfairL2.Morph),
+            CaseWith(x => x.Super.CardNorfairL2.Grapple),
+            CaseWith(x => x.Super.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Super.Varia.Morph),
+            CaseWith(x => x.Super.Varia.Grapple),
+            CaseWith(x => x.Super.Varia.HiJump),
+            CaseWith(x => x.Super.Varia.SpaceJump),
+        };
+
+        #endregion
+
+        #region Norfair Upper Crocomire
+
+        protected override List<Case> NorfairUpperCrocomire => new() {
+            CaseWith(x => x.Morph.Bombs.Super.Varia.CardNorfairL2),
+            CaseWith(x => x.Morph.Bombs.Super.ETank(5).CardNorfairL2),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.SpringBall),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.Ice),
+            CaseWith(x => x.Morph.PowerBomb.Super.ETank(5).CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.ETank(5).CardNorfairL2.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.ETank(5).CardNorfairL2.SpringBall),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.CardNorfairL2.HiJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.CardNorfairL2.SpringBall),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.CardNorfairL2.Ice),
+            CaseWith(x => x.SpeedBooster.Super.Morph.ETank(2)),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Varia),
+            CaseWith(x => x.Flute.CardNorfairL1.Morph.PowerBomb.SpeedBooster.ETank(3)),
+            CaseWith(x => x.Flute.CardNorfairL1.Morph.PowerBomb.SpeedBooster.Varia),
+            CaseWith(x => x.Flute.SpeedBooster.ETank(2).Missile),
+            CaseWith(x => x.Flute.SpeedBooster.ETank(2).Super),
+            CaseWith(x => x.Flute.SpeedBooster.ETank(2).Wave),
+            CaseWith(x => x.Flute.SpeedBooster.Varia.Missile),
+            CaseWith(x => x.Flute.SpeedBooster.Varia.Super),
+            CaseWith(x => x.Flute.SpeedBooster.Varia.Wave),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.SpaceJump.Morph),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.HiJump.Morph),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.Morph.SpringBall),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.Ice.Morph),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.SpaceJump.Morph),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.HiJump.Morph),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.Morph.SpringBall),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.Ice.Morph),
+            CaseWith(x => x.Flute.ETank(5).Missile.CardNorfairL2.SpaceJump.Morph.PowerBomb),
+            CaseWith(x => x.Flute.ETank(5).Missile.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.Flute.ETank(5).Missile.CardNorfairL2.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.Flute.ETank(5).Missile.CardNorfairL2.Morph.SpringBall.PowerBomb),
+            CaseWith(x => x.Glove.Lamp.CardNorfairL1.Morph.PowerBomb.SpeedBooster.ETank(3)),
+            CaseWith(x => x.Glove.Lamp.CardNorfairL1.Morph.PowerBomb.SpeedBooster.Varia),
+            CaseWith(x => x.Glove.Lamp.SpeedBooster.ETank(2).Missile),
+            CaseWith(x => x.Glove.Lamp.SpeedBooster.ETank(2).Super),
+            CaseWith(x => x.Glove.Lamp.SpeedBooster.ETank(2).Wave),
+            CaseWith(x => x.Glove.Lamp.SpeedBooster.Varia.Missile),
+            CaseWith(x => x.Glove.Lamp.SpeedBooster.Varia.Super),
+            CaseWith(x => x.Glove.Lamp.SpeedBooster.Varia.Wave),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.SpaceJump.Morph),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.HiJump.Morph),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.Morph.SpringBall),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.Ice.Morph),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.SpaceJump.Morph),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.HiJump.Morph),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.Morph.SpringBall),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.Ice.Morph),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Missile.CardNorfairL2.SpaceJump.Morph.PowerBomb),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Missile.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Missile.CardNorfairL2.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.Glove.Lamp.ETank(5).Missile.CardNorfairL2.Morph.SpringBall.PowerBomb),
+            CaseWith(x => x.Varia.Flute.Mitt.ScrewAttack.SpaceJump.Super.ETank(2).CardNorfairL2),
+            CaseWith(x => x.Varia.Flute.Mitt.ScrewAttack.SpaceJump.Super.ETank(2).Morph),
+        };
+
+        protected override List<Case> EnergyTankCrocomire => new() {
+            CaseWith(x => x.CardNorfairBoss),
+        };
+
+        protected override List<Case> PowerBombCrocomire => new() {
+            CaseWith(x => x.CardNorfairBoss),
+        };
+
+        protected override List<Case> MissileBelowCrocomire => new() {
+            CaseWith(x => x.CardNorfairBoss.Morph),
+        };
+
+        protected override List<Case> MissileGrapplingBeam => new() {
+            CaseWith(x => x.CardNorfairBoss.SpeedBooster),
+            CaseWith(x => x.CardNorfairBoss.Morph.SpaceJump),
+            CaseWith(x => x.CardNorfairBoss.Morph.Bombs),
+            CaseWith(x => x.CardNorfairBoss.Morph.Grapple),
+        };
+
+        protected override List<Case> GrapplingBeam => new() {
+            CaseWith(x => x.CardNorfairBoss.SpaceJump),
+            CaseWith(x => x.CardNorfairBoss.Morph),
+            CaseWith(x => x.CardNorfairBoss.Grapple),
+            CaseWith(x => x.CardNorfairBoss.HiJump.SpeedBooster),
+        };
+
+        #endregion
+
+        #region Norfair Lower West
+
+        protected override List<Case> NorfairLowerWest => new() {
+            CaseWith(x => x.Morph.Bombs.Super.Varia.CardNorfairL2.PowerBomb.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.SpaceJump.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.SpringBall.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.Ice.Gravity),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Varia.PowerBomb.HiJump),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Varia.PowerBomb.Gravity),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.SpaceJump.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.Morph.Bombs.PowerBomb.Gravity),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.Morph.SpringBall.PowerBomb.Gravity),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.Ice.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Flute.Varia.SpeedBooster.CardNorfairL2.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Flute.Varia.SpeedBooster.CardNorfairL2.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Flute.Varia.SpeedBooster.Missile.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Flute.Varia.SpeedBooster.Missile.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Flute.Varia.SpeedBooster.Wave.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Flute.Varia.SpeedBooster.Wave.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.SpaceJump.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.Morph.Bombs.PowerBomb.Gravity),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.Morph.SpringBall.PowerBomb.Gravity),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.Ice.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Glove.Lamp.Varia.SpeedBooster.CardNorfairL2.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Glove.Lamp.Varia.SpeedBooster.CardNorfairL2.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Glove.Lamp.Varia.SpeedBooster.Missile.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Glove.Lamp.Varia.SpeedBooster.Missile.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Glove.Lamp.Varia.SpeedBooster.Wave.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Glove.Lamp.Varia.SpeedBooster.Wave.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Flute.Mitt.Morph.Bombs),
+            CaseWith(x => x.Flute.Mitt.Morph.PowerBomb),
+            CaseWith(x => x.Flute.Mitt.ScrewAttack),
+        };
+
+        // MissileMickeyMouseRoom is unchanged by virtue of IBJ, PBs, Space already
+        // satisfying the exit condition, thus shortcuting UN2 keycard access
+
+        #endregion
+
+        #region Norfair Lower East
+
+        protected override List<Case> NorfairLowerEast => new() {
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Morph.Bombs.Super.CardNorfairL2.PowerBomb.Gravity),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Morph.PowerBomb.Super.CardNorfairL2.SpaceJump.Gravity),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Morph.PowerBomb.Super.CardNorfairL2.HiJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Morph.PowerBomb.Super.CardNorfairL2.SpringBall.Gravity),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Morph.PowerBomb.Super.CardNorfairL2.Ice.Gravity.Charge),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.SpeedBooster.Super.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.SpeedBooster.Super.Morph.PowerBomb.Gravity.SpaceJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.SpeedBooster.Super.Morph.PowerBomb.Gravity.Bombs),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.SpeedBooster.Super.Morph.PowerBomb.Gravity.SpringBall),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.SpeedBooster.Super.Morph.PowerBomb.Gravity.Ice.Charge),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.Missile.CardNorfairL2.SpaceJump.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.Missile.CardNorfairL2.Morph.Bombs.PowerBomb.Gravity),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.Missile.CardNorfairL2.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.Missile.CardNorfairL2.Morph.SpringBall.PowerBomb.Gravity),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.Missile.CardNorfairL2.Ice.Morph.PowerBomb.Gravity.Charge),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.CardNorfairL2.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.CardNorfairL2.Morph.PowerBomb.Gravity.SpaceJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.CardNorfairL2.Morph.PowerBomb.Gravity.Bombs),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.CardNorfairL2.Morph.PowerBomb.Gravity.SpringBall),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.CardNorfairL2.Morph.PowerBomb.Gravity.Ice.Charge),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.Missile.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.Missile.Morph.PowerBomb.Gravity.SpaceJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.Missile.Morph.PowerBomb.Gravity.Bombs),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.Missile.Morph.PowerBomb.Gravity.SpringBall),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.Missile.Morph.PowerBomb.Gravity.Ice.Charge),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.Wave.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.Wave.Morph.PowerBomb.Gravity.SpaceJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.Wave.Morph.PowerBomb.Gravity.Bombs),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.Wave.Morph.PowerBomb.Gravity.SpringBall),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.SpeedBooster.Wave.Morph.PowerBomb.Gravity.Ice.Charge),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.Missile.CardNorfairL2.SpaceJump.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.Missile.CardNorfairL2.Morph.Bombs.PowerBomb.Gravity),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.Missile.CardNorfairL2.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.Missile.CardNorfairL2.Morph.SpringBall.PowerBomb.Gravity),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.Missile.CardNorfairL2.Ice.Morph.PowerBomb.Gravity.Charge),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.CardNorfairL2.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.CardNorfairL2.Morph.PowerBomb.Gravity.SpaceJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.CardNorfairL2.Morph.PowerBomb.Gravity.Bombs),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.CardNorfairL2.Morph.PowerBomb.Gravity.SpringBall),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.CardNorfairL2.Morph.PowerBomb.Gravity.Ice.Charge),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.Missile.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.Missile.Morph.PowerBomb.Gravity.SpaceJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.Missile.Morph.PowerBomb.Gravity.Bombs),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.Missile.Morph.PowerBomb.Gravity.SpringBall),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.Missile.Morph.PowerBomb.Gravity.Ice.Charge),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.Wave.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.Wave.Morph.PowerBomb.Gravity.SpaceJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.Wave.Morph.PowerBomb.Gravity.Bombs),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.Wave.Morph.PowerBomb.Gravity.SpringBall),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Glove.Lamp.SpeedBooster.Wave.Morph.PowerBomb.Gravity.Ice.Charge),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.Mitt.Morph.Bombs.Super),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.Mitt.Morph.PowerBomb.Super.SpaceJump),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.Mitt.Morph.PowerBomb.Super.SpringBall),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.Mitt.Morph.PowerBomb.Super.SpeedBooster.Ice.Charge),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.Mitt.ScrewAttack.Super.SpaceJump),
+        };
+
+        protected override List<Case> MissileLowerNorfairAboveFireFleaRoom => NorfairLowerEastCanExit;
+
+        protected override List<Case> PowerBombLowerNorfairAboveFireFleaRoom => new() {
+            CaseWith(x => x.Morph.CardNorfairL2.Bombs),
+            CaseWith(x => x.Morph.CardNorfairL2.PowerBomb),
+            CaseWith(x => x.Morph.Missile.SpeedBooster.PowerBomb),
+            CaseWith(x => x.Morph.Missile.SpaceJump.PowerBomb),
+            CaseWith(x => x.Morph.Missile.Bombs),
+            CaseWith(x => x.Morph.Missile.Grapple.PowerBomb),
+            CaseWith(x => x.Morph.Missile.HiJump.SpringBall.PowerBomb),
+            CaseWith(x => x.Morph.Missile.HiJump.Ice.PowerBomb),
+            CaseWith(x => x.Morph.Super.SpeedBooster.PowerBomb),
+            CaseWith(x => x.Morph.Super.SpaceJump.PowerBomb),
+            CaseWith(x => x.Morph.Super.Bombs),
+            CaseWith(x => x.Morph.Super.Grapple.PowerBomb),
+            CaseWith(x => x.Morph.Super.HiJump.SpringBall.PowerBomb),
+            CaseWith(x => x.Morph.Super.HiJump.Ice.PowerBomb),
+            CaseWith(x => x.Morph.Wave.SpeedBooster.PowerBomb),
+            CaseWith(x => x.Morph.Wave.SpaceJump.PowerBomb),
+            CaseWith(x => x.Morph.Wave.Bombs),
+            CaseWith(x => x.Morph.Wave.Grapple.PowerBomb),
+            CaseWith(x => x.Morph.Wave.HiJump.SpringBall.PowerBomb),
+            CaseWith(x => x.Morph.Wave.HiJump.Ice.PowerBomb),
+            CaseWith(x => x.ETank(5).Morph.Bombs),
+            CaseWith(x => x.ETank(5).Morph.PowerBomb),
+        };
+
+        protected override List<Case> PowerBombPowerBombsOfShame => new() {
+            CaseWith(x => x.Morph.CardNorfairL2.PowerBomb),
+            CaseWith(x => x.Morph.Missile.SpeedBooster.PowerBomb),
+            CaseWith(x => x.Morph.Missile.SpaceJump.PowerBomb),
+            CaseWith(x => x.Morph.Missile.Bombs.PowerBomb),
+            CaseWith(x => x.Morph.Missile.Grapple.PowerBomb),
+            CaseWith(x => x.Morph.Missile.HiJump.SpringBall.PowerBomb),
+            CaseWith(x => x.Morph.Missile.HiJump.Ice.PowerBomb),
+            CaseWith(x => x.Morph.Super.SpeedBooster.PowerBomb),
+            CaseWith(x => x.Morph.Super.SpaceJump.PowerBomb),
+            CaseWith(x => x.Morph.Super.Bombs.PowerBomb),
+            CaseWith(x => x.Morph.Super.Grapple.PowerBomb),
+            CaseWith(x => x.Morph.Super.HiJump.SpringBall.PowerBomb),
+            CaseWith(x => x.Morph.Super.HiJump.Ice.PowerBomb),
+            CaseWith(x => x.Morph.Wave.SpeedBooster.PowerBomb),
+            CaseWith(x => x.Morph.Wave.SpaceJump.PowerBomb),
+            CaseWith(x => x.Morph.Wave.Bombs.PowerBomb),
+            CaseWith(x => x.Morph.Wave.Grapple.PowerBomb),
+            CaseWith(x => x.Morph.Wave.HiJump.SpringBall.PowerBomb),
+            CaseWith(x => x.Morph.Wave.HiJump.Ice.PowerBomb),
+            CaseWith(x => x.ETank(5).Morph.PowerBomb),
+        };
+
+        protected override List<Case> MissileLowerNorfairNearWaveBeam => new() {
+            CaseWith(x => x.Morph.CardNorfairL2.Bombs),
+            CaseWith(x => x.Morph.CardNorfairL2.PowerBomb),
+            CaseWith(x => x.Morph.CardNorfairL2.ScrewAttack),
+            CaseWith(x => x.Morph.Missile.SpeedBooster.PowerBomb),
+            CaseWith(x => x.Morph.Missile.SpeedBooster.ScrewAttack),
+            CaseWith(x => x.Morph.Missile.SpaceJump.PowerBomb),
+            CaseWith(x => x.Morph.Missile.SpaceJump.ScrewAttack),
+            CaseWith(x => x.Morph.Missile.Bombs),
+            CaseWith(x => x.Morph.Missile.Grapple.PowerBomb),
+            CaseWith(x => x.Morph.Missile.Grapple.ScrewAttack),
+            CaseWith(x => x.Morph.Missile.HiJump.SpringBall.PowerBomb),
+            CaseWith(x => x.Morph.Missile.HiJump.SpringBall.ScrewAttack),
+            CaseWith(x => x.Morph.Missile.HiJump.Ice.PowerBomb),
+            CaseWith(x => x.Morph.Missile.HiJump.Ice.ScrewAttack),
+            CaseWith(x => x.Morph.Super.SpeedBooster.PowerBomb),
+            CaseWith(x => x.Morph.Super.SpeedBooster.ScrewAttack),
+            CaseWith(x => x.Morph.Super.SpaceJump.PowerBomb),
+            CaseWith(x => x.Morph.Super.SpaceJump.ScrewAttack),
+            CaseWith(x => x.Morph.Super.Bombs),
+            CaseWith(x => x.Morph.Super.Grapple.PowerBomb),
+            CaseWith(x => x.Morph.Super.Grapple.ScrewAttack),
+            CaseWith(x => x.Morph.Super.HiJump.SpringBall.PowerBomb),
+            CaseWith(x => x.Morph.Super.HiJump.SpringBall.ScrewAttack),
+            CaseWith(x => x.Morph.Super.HiJump.Ice.PowerBomb),
+            CaseWith(x => x.Morph.Super.HiJump.Ice.ScrewAttack),
+            CaseWith(x => x.Morph.Wave.SpeedBooster.PowerBomb),
+            CaseWith(x => x.Morph.Wave.SpeedBooster.ScrewAttack),
+            CaseWith(x => x.Morph.Wave.SpaceJump.PowerBomb),
+            CaseWith(x => x.Morph.Wave.SpaceJump.ScrewAttack),
+            CaseWith(x => x.Morph.Wave.Bombs),
+            CaseWith(x => x.Morph.Wave.Grapple.PowerBomb),
+            CaseWith(x => x.Morph.Wave.Grapple.ScrewAttack),
+            CaseWith(x => x.Morph.Wave.HiJump.SpringBall.PowerBomb),
+            CaseWith(x => x.Morph.Wave.HiJump.SpringBall.ScrewAttack),
+            CaseWith(x => x.Morph.Wave.HiJump.Ice.PowerBomb),
+            CaseWith(x => x.Morph.Wave.HiJump.Ice.ScrewAttack),
+            CaseWith(x => x.ETank(5).Morph.Bombs),
+            CaseWith(x => x.ETank(5).Morph.PowerBomb),
+            CaseWith(x => x.ETank(5).Morph.ScrewAttack),
+        };
+
+        protected override List<Case> EnergyTankRidley => new() {
+            CaseWith(x => x.Morph.CardNorfairL2.CardLowerNorfairBoss.PowerBomb.Super),
+            CaseWith(x => x.Morph.Super.SpeedBooster.CardLowerNorfairBoss.PowerBomb),
+            CaseWith(x => x.Morph.Super.SpaceJump.CardLowerNorfairBoss.PowerBomb),
+            CaseWith(x => x.Morph.Super.Bombs.CardLowerNorfairBoss.PowerBomb),
+            CaseWith(x => x.Morph.Super.Grapple.CardLowerNorfairBoss.PowerBomb),
+            CaseWith(x => x.Morph.Super.HiJump.SpringBall.CardLowerNorfairBoss.PowerBomb),
+            CaseWith(x => x.Morph.Super.HiJump.Ice.CardLowerNorfairBoss.PowerBomb),
+            CaseWith(x => x.ETank(5).CardLowerNorfairBoss.Morph.PowerBomb.Super),
+        };
+        
+        protected override List<Case> EnergyTankFirefleas => NorfairLowerEastCanExit;
+
+        List<Case> NorfairLowerEastCanExit => new() {
+            CaseWith(x => x.Morph.CardNorfairL2),
+            CaseWith(x => x.Morph.Missile.SpeedBooster),
+            CaseWith(x => x.Morph.Missile.SpaceJump),
+            CaseWith(x => x.Morph.Missile.Bombs),
+            CaseWith(x => x.Morph.Missile.Grapple),
+            CaseWith(x => x.Morph.Missile.HiJump.SpringBall),
+            CaseWith(x => x.Morph.Missile.HiJump.Ice),
+            CaseWith(x => x.Morph.Super.SpeedBooster),
+            CaseWith(x => x.Morph.Super.SpaceJump),
+            CaseWith(x => x.Morph.Super.Bombs),
+            CaseWith(x => x.Morph.Super.Grapple),
+            CaseWith(x => x.Morph.Super.HiJump.SpringBall),
+            CaseWith(x => x.Morph.Super.HiJump.Ice),
+            CaseWith(x => x.Morph.Wave.SpeedBooster),
+            CaseWith(x => x.Morph.Wave.SpaceJump),
+            CaseWith(x => x.Morph.Wave.Bombs),
+            CaseWith(x => x.Morph.Wave.Grapple),
+            CaseWith(x => x.Morph.Wave.HiJump.SpringBall),
+            CaseWith(x => x.Morph.Wave.HiJump.Ice),
+            CaseWith(x => x.ETank(5)),
+        };
+
+        #endregion
+
+        #region Light World North West
+
+        protected override List<Case> GraveyardLedge => new() {
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> KingsTomb => new() {
+            CaseWith(x => x.Boots.Mitt),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Hammer.Glove),
+        };
+
+        #endregion
+
+        #region Light World South
+
+        protected override List<Case> SouthOfGrove => new() {
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> CheckerboardCave => new() {
+            CaseWith(x => x.Mirror.Flute.Mitt),
+            CaseWith(x => x.Mirror.CardNorfairL2.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Glove),
+            CaseWith(x => x.Mirror.CardNorfairL2.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Glove),
+            CaseWith(x => x.Mirror.CardNorfairL2.Varia.Super.HiJump.Morph.PowerBomb.Glove),
+            CaseWith(x => x.Mirror.CardNorfairL2.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Glove),
+            CaseWith(x => x.Mirror.CardNorfairL2.Varia.Super.Ice.Gravity.Morph.PowerBomb.Glove),
+            CaseWith(x => x.Mirror.SpeedBooster.Varia.Super.HiJump.Morph.PowerBomb.Glove),
+            CaseWith(x => x.Mirror.SpeedBooster.Varia.Super.Gravity.Morph.PowerBomb.Glove),
+        };
+
+        protected override List<Case> BombosTablet => new() {
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> LakeHyliaIsland => new() {
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Hammer.Glove),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Mitt),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple),
+        };
+
+        #endregion
+
+        #region Dark World North West
+
+        protected override List<Case> DarkWorldNorthWest => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        #endregion
+
+        #region Dark World North East
+
+        protected override List<Case> DarkWorldNorthEast => new() {
+            CaseWith(x => x.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers),
+        };
+
+        protected override List<Case> PyramidFairy => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers.Mirror),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove.Mirror),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers.Mirror),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove.Mirror),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt.Mirror.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Mitt.Mirror.MasterSword.Lamp.KeyCT(2)),
+        };
+
+        #endregion
+
+        #region Dark World South
+
+        protected override List<Case> DarkWorldSouth => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        #endregion
+
+        #region Dark World Mire
+
+        protected override List<Case> DarkWorldMire => new() {
+            CaseWith(x => x.Flute.Mitt),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.Bombs.Gravity.PowerBomb),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.SpringBall.Gravity.PowerBomb),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Ice.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.SpeedBooster.Varia.Super.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.SpeedBooster.Varia.Super.Gravity.Morph.PowerBomb),
+        };
+
+        #endregion
+
+        #region Desert Palace
+
+        protected override List<Case> DesertPalace => new() {
+            CaseWith(x => x.Book),
+            CaseWith(x => x.Mirror.Mitt.Flute),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.HiJump.Morph.PowerBomb.Mirror),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror),
+            CaseWith(x => x.SpeedBooster.Varia.Super.HiJump.Morph.PowerBomb.Mirror),
+            CaseWith(x => x.SpeedBooster.Varia.Super.Gravity.Morph.PowerBomb.Mirror),
+        };
+
+        protected override List<Case> DesertPalaceLanmolas => new() {
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Firerod),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Lamp.Sword),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Lamp.Hammer),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Lamp.Bow),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Lamp.Icerod),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Lamp.Byrna),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Lamp.Somaria),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Firerod),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Sword),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Hammer),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Bow),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Icerod),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Byrna),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Somaria),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Firerod),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Sword),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Hammer),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Bow),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Icerod),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Byrna),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.Bombs.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Somaria),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Firerod),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Sword),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Hammer),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Bow),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Icerod),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Byrna),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Somaria),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Firerod),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Sword),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Hammer),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Bow),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Icerod),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Byrna),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Morph.SpringBall.Gravity.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Somaria),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Firerod),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Sword),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Hammer),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Bow),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Icerod),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Byrna),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Ice.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Somaria),
+            CaseWith(x => x.SpeedBooster.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Firerod),
+            CaseWith(x => x.SpeedBooster.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Sword),
+            CaseWith(x => x.SpeedBooster.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Hammer),
+            CaseWith(x => x.SpeedBooster.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Bow),
+            CaseWith(x => x.SpeedBooster.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Icerod),
+            CaseWith(x => x.SpeedBooster.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Byrna),
+            CaseWith(x => x.SpeedBooster.Varia.Super.HiJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Somaria),
+            CaseWith(x => x.SpeedBooster.Varia.Super.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Firerod),
+            CaseWith(x => x.SpeedBooster.Varia.Super.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Sword),
+            CaseWith(x => x.SpeedBooster.Varia.Super.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Hammer),
+            CaseWith(x => x.SpeedBooster.Varia.Super.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Bow),
+            CaseWith(x => x.SpeedBooster.Varia.Super.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Icerod),
+            CaseWith(x => x.SpeedBooster.Varia.Super.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Byrna),
+            CaseWith(x => x.SpeedBooster.Varia.Super.Gravity.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Somaria),
+        };
+
+        #endregion
+
+        #region Palace of Darkness
+
+        protected override List<Case> PalaceOfDarkness => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers),
+        };
+
+        protected override List<Case> PalaceOfDarknessBigKeyChest => new() {
+            CaseWith(x => x.Has.KeyPD.KeyPD(1)),
+            CaseWith(x => x.KeyPD(6)),
+        };
+
+        protected override List<Case> PalaceOfDarknessCompassChest => new() {
+            CaseWith(x => x.KeyPD(4)),
+        };
+
+        protected override List<Case> PalaceOfDarknessHarmlessHellway => new() {
+            CaseWith(x => x.Has.KeyPD.KeyPD(4)),
+            CaseWith(x => x.KeyPD(6)),
+        };
+
+        protected override List<Case> PalaceOfDarknessDarkBasement => new() {
+            CaseWith(x => x.Lamp.KeyPD(4)),
+        };
+
+        protected override List<Case> PalaceOfDarknessDarkMaze => new() {
+            CaseWith(x => x.Lamp.KeyPD(6)),
+        };
+
+        protected override List<Case> PalaceOfDarknessBigChest => new() {
+            CaseWith(x => x.BigKeyPD.Lamp.KeyPD(6)),
+        };
+
+        #endregion
+
+        #region Swamp Palace
+
+        protected override List<Case> SwampPalace => new() {
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Sword.Cape.Lamp.KeyCT(2).Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.MasterSword.Lamp.KeyCT(2).Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Mitt),
+        };
+
+        #endregion
+
+        #region Skull Woods
+
+        protected override List<Case> SkullWoods => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        #endregion
+
+        #region Thieves' Town
+
+        protected override List<Case> ThievesTown => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Charge.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.Ice.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Missile.HiJump.Ice.Grapple.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        #endregion
+
+        #region Misery Mire
+
+        protected override List<Case> MiseryMire => new() {
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.Flute.Mitt),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.CardNorfairL2.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.CardNorfairL2.Varia.Super.Morph.Bombs.Gravity.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.CardNorfairL2.Varia.Super.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.CardNorfairL2.Varia.Super.Morph.SpringBall.Gravity.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.CardNorfairL2.Varia.Super.Ice.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.SpeedBooster.Varia.Super.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.SpeedBooster.Varia.Super.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.Flute.Mitt),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.CardNorfairL2.Varia.Super.SpaceJump.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.CardNorfairL2.Varia.Super.Morph.Bombs.Gravity.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.CardNorfairL2.Varia.Super.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.CardNorfairL2.Varia.Super.Morph.SpringBall.Gravity.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.CardNorfairL2.Varia.Super.Ice.Gravity.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.SpeedBooster.Varia.Super.HiJump.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.SpeedBooster.Varia.Super.Gravity.Morph.PowerBomb),
+        };
+
+        #endregion
+
+        #region Turtle Rock
+
+        protected override List<Case> TurtleRockBigKeyChest => new() {
+            CaseWith(x => x.Has.BigKeyTR.KeyTR(2)),
+            CaseWith(x => x.Has.KeyTR.KeyTR(3)),
+            CaseWith(x => x.KeyTR(4)),
+        };
+
+        #endregion
+
+    }
+
+}

--- a/Randomizer.SMZ3.Tests/Logic/SMNormal.cs
+++ b/Randomizer.SMZ3.Tests/Logic/SMNormal.cs
@@ -1,0 +1,1841 @@
+﻿using System.Collections.Generic;
+
+namespace Randomizer.SMZ3.Tests.Logic {
+
+    public class SMNormal : LogicCases {
+
+        #region Crateria West
+
+        protected override List<Case> CrateriaWest => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+            CaseWith(x => x.ScrewAttack),
+            CaseWith(x => x.SpeedBooster),
+        };
+
+        protected override List<Case> EnergyTankTerminator => CaseWithNothing;
+
+        protected override List<Case> EnergyTankGauntlet => new() {
+            CaseWith(x => x.Morph.Bombs.ETank(1)),
+            CaseWith(x => x.Morph.SpaceJump.TwoPowerBombs.ETank(1)),
+            CaseWith(x => x.Morph.SpaceJump.ScrewAttack.ETank(1)),
+            CaseWith(x => x.Morph.SpeedBooster.TwoPowerBombs.ETank(1)),
+            CaseWith(x => x.Morph.SpeedBooster.ScrewAttack.ETank(1)),
+        };
+
+        protected override List<Case> MissileCrateriaGauntlet => new() {
+            CaseWith(x => x.Morph.Bombs.ETank(2)),
+            CaseWith(x => x.Morph.SpaceJump.TwoPowerBombs.ETank(2)),
+            CaseWith(x => x.Morph.SpaceJump.ScrewAttack.PowerBomb.ETank(2)),
+            CaseWith(x => x.Morph.SpeedBooster.TwoPowerBombs.ETank(2)),
+            CaseWith(x => x.Morph.SpeedBooster.ScrewAttack.PowerBomb.ETank(2)),
+        };
+
+        #endregion
+
+        #region Crateria Central
+
+        protected override List<Case> CrateriaCentral => CaseWithNothing;
+
+        protected override List<Case> PowerBombCrateriaSurface => new() {
+            CaseWith(x => x.Morph.PowerBomb.SpeedBooster),
+            CaseWith(x => x.Morph.PowerBomb.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Bombs),
+        };
+
+        protected override List<Case> MissileCrateriaMiddle => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        protected override List<Case> MissileCrateriaBottom => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+            CaseWith(x => x.ScrewAttack),
+        };
+
+        protected override List<Case> SuperMissileCrateria => new() {
+            CaseWith(x => x.Morph.PowerBomb.ETank(2).SpeedBooster),
+        };
+
+        protected override List<Case> Bombs => new() {
+            CaseWith(x => x.Missile.Morph.Bombs),
+            CaseWith(x => x.Missile.Morph.PowerBomb),
+            CaseWith(x => x.Super.Morph.Bombs),
+            CaseWith(x => x.Super.Morph.PowerBomb),
+        };
+
+        #endregion
+
+        #region Crateria East
+
+        protected override List<Case> CrateriaEast => new() {
+            CaseWith(x => x.Morph.PowerBomb.Super),
+            CaseWith(x => x.Morph.PowerBomb.Flute.Ice),
+            CaseWith(x => x.Morph.PowerBomb.Flute.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Flute.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Glove.Lamp.Ice),
+            CaseWith(x => x.Morph.PowerBomb.Glove.Lamp.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.Glove.Lamp.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super.SpeedBooster.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super.SpeedBooster.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super.SpeedBooster.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Super.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Super.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Super.SpeedBooster.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Super.SpaceJump),
+        };
+
+        protected override List<Case> MissileOutsideWreckedShipBottom => new() {
+            CaseWith(x => x.Morph.SpeedBooster),
+            CaseWith(x => x.Morph.Grapple),
+            CaseWith(x => x.Morph.SpaceJump),
+            CaseWith(x => x.Morph.Gravity.Bombs),
+            CaseWith(x => x.Morph.Gravity.HiJump),
+            CaseWith(x => x.Morph.Super.PowerBomb.Gravity),
+            CaseWith(x => x.Morph.MoonPearl.Flippers.Gravity.Sword.Cape.Lamp.KeyCT(2).Super.ScrewAttack),
+            CaseWith(x => x.Morph.MoonPearl.Flippers.Gravity.MasterSword.Lamp.KeyCT(2).Super.ScrewAttack),
+            CaseWith(x => x.Morph.MoonPearl.Flippers.Gravity.Hammer.Glove.Super.ScrewAttack),
+            CaseWith(x => x.Morph.MoonPearl.Flippers.Gravity.Mitt.Super.ScrewAttack),
+        };
+
+        protected override List<Case> MissilesOutsideWreckedShipTopHalf => new() {
+            CaseWith(x => x.Super.Morph.PowerBomb.SpeedBooster),
+            CaseWith(x => x.Super.Morph.PowerBomb.Grapple),
+            CaseWith(x => x.Super.Morph.PowerBomb.SpaceJump),
+            CaseWith(x => x.Super.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.Bombs),
+        };
+
+        protected override List<Case> MissileCrateriaMoat => CaseWithNothing;
+
+        #endregion
+
+        #region Wrecked Ship
+
+        protected override List<Case> WreckedShip => new() {
+            CaseWith(x => x.Super.Morph.PowerBomb.SpeedBooster),
+            CaseWith(x => x.Super.Morph.PowerBomb.Grapple),
+            CaseWith(x => x.Super.Morph.PowerBomb.SpaceJump),
+            CaseWith(x => x.Super.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.Sword.Cape.Lamp.KeyCT(2).ScrewAttack),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.Sword.Cape.Lamp.KeyCT(2).SpeedBooster.HiJump),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.Sword.Cape.Lamp.KeyCT(2).SpaceJump),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.MasterSword.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.MasterSword.Lamp.KeyCT(2).ScrewAttack),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.MasterSword.Lamp.KeyCT(2).SpeedBooster.HiJump),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.MasterSword.Lamp.KeyCT(2).SpaceJump),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.Hammer.Glove.Bombs),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.Hammer.Glove.ScrewAttack),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.Hammer.Glove.SpeedBooster.HiJump),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.Hammer.Glove.SpaceJump),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.Mitt.Bombs),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.Mitt.ScrewAttack),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.Mitt.SpeedBooster.HiJump),
+            CaseWith(x => x.Super.Gravity.MoonPearl.Flippers.Morph.Mitt.SpaceJump),
+        };
+
+        protected override List<Case> MissileWreckedShipMiddle => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        protected override List<Case> ReserveTankWreckedShip => new() {
+            CaseWith(x => x.Morph.PowerBomb.SpeedBooster.Grapple),
+            CaseWith(x => x.Morph.PowerBomb.SpeedBooster.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.SpeedBooster.Varia.ETank(2)),
+            CaseWith(x => x.Morph.PowerBomb.SpeedBooster.ETank(3)),
+        };
+
+        protected override List<Case> MissileGravitySuit => new() {
+            CaseWith(x => x.Morph.Bombs.Grapple),
+            CaseWith(x => x.Morph.Bombs.SpaceJump),
+            CaseWith(x => x.Morph.Bombs.Varia.ETank(2)),
+            CaseWith(x => x.Morph.Bombs.ETank(3)),
+            CaseWith(x => x.Morph.PowerBomb.Grapple),
+            CaseWith(x => x.Morph.PowerBomb.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Varia.ETank(2)),
+            CaseWith(x => x.Morph.PowerBomb.ETank(3)),
+        };
+
+        protected override List<Case> MissileWreckedShipTop => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        protected override List<Case> EnergyTankWreckedShip => new() {
+            CaseWith(x => x.Morph.Bombs.HiJump),
+            CaseWith(x => x.Morph.Bombs.SpaceJump),
+            CaseWith(x => x.Morph.Bombs.SpeedBooster),
+            CaseWith(x => x.Morph.Bombs.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.Morph.PowerBomb.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.SpeedBooster),
+            CaseWith(x => x.Morph.PowerBomb.Gravity),
+        };
+
+        protected override List<Case> SuperMissileWreckedShipLeft => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+        protected override List<Case> SuperMissileWreckedShipRight => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        protected override List<Case> GravitySuit => new() {
+            CaseWith(x => x.Morph.Bombs.Grapple),
+            CaseWith(x => x.Morph.Bombs.SpaceJump),
+            CaseWith(x => x.Morph.Bombs.Varia.ETank(2)),
+            CaseWith(x => x.Morph.Bombs.ETank(3)),
+            CaseWith(x => x.Morph.PowerBomb.Grapple),
+            CaseWith(x => x.Morph.PowerBomb.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Varia.ETank(2)),
+            CaseWith(x => x.Morph.PowerBomb.ETank(3)),
+        };
+
+        #endregion
+
+        #region Brinstar Blue
+
+        protected override List<Case> BrinstarBlue => CaseWithNothing;
+
+        protected override List<Case> MorphingBall => CaseWithNothing;
+
+        protected override List<Case> PowerBombBlueBrinstar => new() {
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        protected override List<Case> MissileBlueBrinstarMiddle => new() {
+            CaseWith(x => x.Morph),
+        };
+
+        protected override List<Case> EnergyTankBrinstarCeiling => new() {
+            CaseWith(x => x.SpaceJump),
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.HiJump),
+            CaseWith(x => x.SpeedBooster),
+            CaseWith(x => x.Ice),
+        };
+
+        protected override List<Case> MissileBlueBrinstarBottom => new() {
+            CaseWith(x => x.Morph),
+        };
+
+        protected override List<Case> MissileBlueBrinstarBillyMays => new() {
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        #endregion
+
+        #region Brinstar Green
+
+        protected override List<Case> BrinstarGreen => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+            CaseWith(x => x.ScrewAttack),
+            CaseWith(x => x.SpeedBooster),
+        };
+
+        protected override List<Case> PowerBombGreenBrinstarBottom => new() {
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        protected override List<Case> MissileGreenBrinstarBelowSuperMissile => new() {
+            CaseWith(x => x.Morph.Bombs.Missile),
+            CaseWith(x => x.Morph.Bombs.Super),
+            CaseWith(x => x.Morph.PowerBomb.Missile),
+            CaseWith(x => x.Morph.PowerBomb.Super),
+        };
+
+        protected override List<Case> SuperMissileGreenBrinstarTop => new() {
+            CaseWith(x => x.Missile.SpeedBooster),
+            CaseWith(x => x.Super.SpeedBooster),
+        };
+        protected override List<Case> ReserveTankBrinstar => new() {
+            CaseWith(x => x.Missile.SpeedBooster),
+            CaseWith(x => x.Super.SpeedBooster),
+        };
+
+        protected override List<Case> MissileGreenBrinstarBehindMissile => new() {
+            CaseWith(x => x.SpeedBooster.Morph.Bombs.Missile),
+            CaseWith(x => x.SpeedBooster.Morph.Bombs.Super),
+            CaseWith(x => x.SpeedBooster.Morph.PowerBomb.Missile),
+            CaseWith(x => x.SpeedBooster.Morph.PowerBomb.Super),
+        };
+
+        protected override List<Case> MissileGreenBrinstarBehindReserveTank => new() {
+            CaseWith(x => x.SpeedBooster.Missile.Morph),
+            CaseWith(x => x.SpeedBooster.Super.Morph),
+        };
+
+        protected override List<Case> EnergyTankEtecoons => new() {
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        protected override List<Case> SuperMissileGreenBrinstarBottom => new() {
+            CaseWith(x => x.Morph.PowerBomb.Super),
+        };
+
+        #endregion
+
+        #region Brinstar Pink
+
+        protected override List<Case> BrinstarPink => new() {
+            CaseWith(x => x.Missile.Morph.Bombs),
+            CaseWith(x => x.Missile.ScrewAttack),
+            CaseWith(x => x.Missile.SpeedBooster),
+            CaseWith(x => x.Super.Morph.Bombs),
+            CaseWith(x => x.Super.ScrewAttack),
+            CaseWith(x => x.Super.SpeedBooster),
+            CaseWith(x => x.Morph.PowerBomb),
+            CaseWith(x => x.Flute.Morph.Wave.Ice),
+            CaseWith(x => x.Flute.Morph.Wave.HiJump),
+            CaseWith(x => x.Flute.Morph.Wave.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.Morph.Wave.Ice),
+            CaseWith(x => x.Glove.Lamp.Morph.Wave.HiJump),
+            CaseWith(x => x.Glove.Lamp.Morph.Wave.SpaceJump),
+        };
+
+        protected override List<Case> SuperMissilePinkBrinstar => new() {
+            CaseWith(x => x.Morph.Bombs.Super),
+            CaseWith(x => x.Morph.PowerBomb.Super),
+        };
+
+        protected override List<Case> MissilePinkBrinstarRoom => CaseWithNothing;
+
+        protected override List<Case> ChargeBeam => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        protected override List<Case> PowerBombPinkBrinstar => new() {
+            CaseWith(x => x.Morph.PowerBomb.Super.ETank(1)),
+        };
+
+        protected override List<Case> MissileGreenBrinstarPipe => new() {
+            CaseWith(x => x.Morph.PowerBomb),
+            CaseWith(x => x.Morph.Super),
+            CaseWith(x => x.Morph.Flute),
+            CaseWith(x => x.Morph.Glove.Lamp),
+        };
+
+        protected override List<Case> EnergyTankWaterway => new() {
+            CaseWith(x => x.Morph.PowerBomb.Missile.SpeedBooster.ETank(1)),
+            CaseWith(x => x.Morph.PowerBomb.Missile.SpeedBooster.Gravity),
+            CaseWith(x => x.Morph.PowerBomb.Super.SpeedBooster.ETank(1)),
+            CaseWith(x => x.Morph.PowerBomb.Super.SpeedBooster.Gravity),
+        };
+
+        protected override List<Case> EnergyTankBrinstarGate => new() {
+            CaseWith(x => x.Morph.PowerBomb.Wave.ETank(1)),
+        };
+
+        #endregion
+
+        #region Brinstar Red
+
+        protected override List<Case> BrinstarRed => new() {
+            CaseWith(x => x.Morph.Bombs.Super),
+            CaseWith(x => x.Morph.PowerBomb.Super),
+            CaseWith(x => x.ScrewAttack.Super.Morph),
+            CaseWith(x => x.SpeedBooster.Super.Morph),
+            CaseWith(x => x.Flute.Ice),
+            CaseWith(x => x.Flute.HiJump),
+            CaseWith(x => x.Flute.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.Ice),
+            CaseWith(x => x.Glove.Lamp.HiJump),
+            CaseWith(x => x.Glove.Lamp.SpaceJump),
+        };
+
+        protected override List<Case> XRayScope => new() {
+            CaseWith(x => x.Morph.PowerBomb.Missile.Grapple),
+            CaseWith(x => x.Morph.PowerBomb.Missile.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Grapple),
+            CaseWith(x => x.Morph.PowerBomb.Super.SpaceJump),
+        };
+
+        protected override List<Case> PowerBombRedBrinstarSidehopperRoom => new() {
+            CaseWith(x => x.Morph.PowerBomb.Super),
+        };
+
+        protected override List<Case> PowerBombRedBrinstarSpikeRoom => new() {
+            CaseWith(x => x.Morph.PowerBomb.Super),
+            CaseWith(x => x.Ice.Super),
+        };
+
+        protected override List<Case> MissileRedBrinstarSpikeRoom => new() {
+            CaseWith(x => x.Morph.PowerBomb.Super),
+        };
+
+        protected override List<Case> Spazer => new() {
+            CaseWith(x => x.Morph.Bombs.Super),
+            CaseWith(x => x.Morph.PowerBomb.Super),
+        };
+
+        #endregion
+
+        #region Brinstar Kraid
+
+        protected override List<Case> BrinstarKraid => new() {
+            CaseWith(x => x.Morph.Bombs.Super),
+            CaseWith(x => x.Morph.PowerBomb.Super),
+        };
+
+        protected override List<Case> EnergyTankKraid => CaseWithNothing;
+        protected override List<Case> VariaSuit => CaseWithNothing;
+
+        protected override List<Case> MissileKraid => new() {
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        #endregion
+
+        #region Maridia Outer
+
+        protected override List<Case> MaridiaOuter => new() {
+            CaseWith(x => x.Gravity.Morph.PowerBomb.Super),
+            CaseWith(x => x.Gravity.Flute.Morph.PowerBomb),
+            CaseWith(x => x.Gravity.Glove.Lamp.Morph.PowerBomb),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Sword.Cape.Lamp.KeyCT(2).PowerBomb),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Sword.Cape.Lamp.KeyCT(2).ScrewAttack),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.MasterSword.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.MasterSword.Lamp.KeyCT(2).PowerBomb),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.MasterSword.Lamp.KeyCT(2).ScrewAttack),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Hammer.Glove.Bombs),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Hammer.Glove.PowerBomb),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Hammer.Glove.ScrewAttack),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Mitt.Bombs),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Mitt.PowerBomb),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Mitt.ScrewAttack),
+        };
+
+        protected override List<Case> MissileGreenMaridiaShinespark => new() {
+            CaseWith(x => x.SpeedBooster),
+        };
+
+        protected override List<Case> SuperMissileGreenMaridia => CaseWithNothing;
+
+        protected override List<Case> EnergyTankMamaTurtle => new() {
+            CaseWith(x => x.Missile.SpaceJump),
+            CaseWith(x => x.Missile.Morph.Bombs),
+            CaseWith(x => x.Missile.SpeedBooster),
+            CaseWith(x => x.Missile.Grapple),
+            CaseWith(x => x.Super.SpaceJump),
+            CaseWith(x => x.Super.Morph.Bombs),
+            CaseWith(x => x.Super.SpeedBooster),
+            CaseWith(x => x.Super.Grapple),
+        };
+
+        protected override List<Case> MissileGreenMaridiaTatori => new() {
+            CaseWith(x => x.Missile),
+            CaseWith(x => x.Super),
+        };
+
+        #endregion
+
+        #region Maridia Inner
+
+        protected override List<Case> MaridiaInner => new() {
+            CaseWith(x => x.Gravity.Morph.PowerBomb.Super.SpaceJump),
+            CaseWith(x => x.Gravity.Morph.PowerBomb.Super.Bombs),
+            CaseWith(x => x.Gravity.Morph.PowerBomb.Super.SpeedBooster),
+            CaseWith(x => x.Gravity.Morph.PowerBomb.Super.Grapple),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Hammer.Glove),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Mitt),
+        };
+
+        protected override List<Case> YellowMaridiaWateringHole => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+        protected override List<Case> MissileYellowMaridiaFalseWall => new() {
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        protected override List<Case> PlasmaBeam => new() {
+            CaseWith(x => x.SpeedBooster.Gravity.HiJump.ScrewAttack),
+            CaseWith(x => x.SpeedBooster.Gravity.HiJump.Plasma),
+            CaseWith(x => x.SpeedBooster.Gravity.SpaceJump.ScrewAttack),
+            CaseWith(x => x.SpeedBooster.Gravity.SpaceJump.Plasma),
+            CaseWith(x => x.SpeedBooster.Gravity.Morph.Bombs.ScrewAttack),
+            CaseWith(x => x.SpeedBooster.Gravity.Morph.Bombs.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).SpaceJump.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).SpaceJump.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).SpaceJump.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).SpaceJump.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Bombs.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Bombs.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.SpaceJump.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.SpaceJump.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Bombs.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Bombs.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.SpaceJump.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.SpaceJump.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Bombs.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Bombs.Plasma),
+        };
+
+        protected override List<Case> LeftMaridiaSandPitRoom => new() {
+            CaseWith(x => x.SpaceJump.Super.Morph.PowerBomb),
+            CaseWith(x => x.Morph.Bombs.Super),
+            CaseWith(x => x.SpeedBooster.Super.Morph.PowerBomb),
+            CaseWith(x => x.Grapple.Super.Morph.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super.PowerBomb),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Super.PowerBomb),
+        };
+
+        protected override List<Case> MissileRightMaridiaSandPitRoom => RightMaridiaSandPitRoom;
+        protected override List<Case> PowerBombRightMaridiaSandPitRoom => RightMaridiaSandPitRoom;
+
+        List<Case> RightMaridiaSandPitRoom => new() {
+            CaseWith(x => x.SpaceJump.Super),
+            CaseWith(x => x.Morph.Bombs.Super),
+            CaseWith(x => x.SpeedBooster.Super),
+            CaseWith(x => x.Grapple.Super),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Super),
+        };
+
+        protected override List<Case> PinkMaridia => new() {
+            CaseWith(x => x.SpeedBooster),
+        };
+
+        protected override List<Case> SpringBall => new() {
+            CaseWith(x => x.Super.Grapple.Morph.PowerBomb.SpaceJump),
+            CaseWith(x => x.Super.Grapple.Morph.PowerBomb.HiJump),
+        };
+
+        protected override List<Case> MissileDraygon => new() {
+            CaseWith(x => x.SpeedBooster),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt),
+        };
+
+        protected override List<Case> EnergyTankBotwoon => new() {
+            CaseWith(x => x.SpeedBooster),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt),
+        };
+
+        protected override List<Case> SpaceJump => new() {
+            CaseWith(x => x.SpeedBooster.Gravity.HiJump),
+            CaseWith(x => x.SpeedBooster.Gravity.SpaceJump),
+            CaseWith(x => x.SpeedBooster.Gravity.Morph.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Bombs),
+        };
+
+        #endregion
+
+        #region Norfair Upper West
+
+        protected override List<Case> NorfairUpperWest => new() {
+            CaseWith(x => x.Morph.Bombs.Super),
+            CaseWith(x => x.Morph.PowerBomb.Super),
+            CaseWith(x => x.ScrewAttack.Super.Morph),
+            CaseWith(x => x.SpeedBooster.Super.Morph),
+            CaseWith(x => x.Flute),
+            CaseWith(x => x.Glove.Lamp),
+        };
+
+        protected override List<Case> MissileLavaRoom => new() {
+            CaseWith(x => x.Varia.Missile.SpaceJump.Morph),
+            CaseWith(x => x.Varia.Missile.Morph.Bombs),
+            CaseWith(x => x.Varia.Missile.HiJump.Morph),
+            CaseWith(x => x.Varia.Missile.SpeedBooster.Morph),
+            CaseWith(x => x.Varia.Super.SpaceJump.Morph),
+            CaseWith(x => x.Varia.Super.Morph.Bombs),
+            CaseWith(x => x.Varia.Super.HiJump.Morph),
+            CaseWith(x => x.Varia.Super.SpeedBooster.Morph),
+        };
+
+        protected override List<Case> IceBeam => new() {
+            CaseWith(x => x.Super.Morph.Bombs.Varia.SpeedBooster),
+            CaseWith(x => x.Super.Morph.PowerBomb.Varia.SpeedBooster),
+        };
+
+        protected override List<Case> MissileBelowIceBeam => new() {
+            CaseWith(x => x.Super.Morph.PowerBomb.Varia.SpeedBooster),
+        };
+
+        protected override List<Case> HiJumpBoots => new() {
+            CaseWith(x => x.Missile.Morph.Bombs),
+            CaseWith(x => x.Missile.Morph.PowerBomb),
+            CaseWith(x => x.Super.Morph.Bombs),
+            CaseWith(x => x.Super.Morph.PowerBomb),
+        };
+
+        protected override List<Case> MissileHiJumpBoots => new() {
+            CaseWith(x => x.Missile.Morph),
+            CaseWith(x => x.Super.Morph),
+        };
+
+        protected override List<Case> EnergyTankHiJumpBoots => new() {
+            CaseWith(x => x.Missile),
+            CaseWith(x => x.Super),
+        };
+
+        #endregion
+
+        #region Norfair Upper East
+
+        protected override List<Case> NorfairUpperEast => new() {
+            CaseWith(x => x.Morph.Bombs.Super.Varia),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.HiJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.SpaceJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.HiJump),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Varia),
+            CaseWith(x => x.Flute.Varia.Super.SpaceJump),
+            CaseWith(x => x.Flute.Varia.Super.HiJump),
+            CaseWith(x => x.Flute.Varia.Super.SpeedBooster),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.HiJump),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.SpeedBooster),
+        };
+
+        protected override List<Case> ReserveTankNorfair => new() {
+            CaseWith(x => x.Morph.SpaceJump),
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.Grapple.SpeedBooster),
+            CaseWith(x => x.Morph.Grapple.PowerBomb),
+            CaseWith(x => x.Morph.HiJump),
+            CaseWith(x => x.Morph.Ice),
+        };
+        protected override List<Case> MissileNorfairReserveTank => new() {
+            CaseWith(x => x.Morph.SpaceJump),
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.Grapple.SpeedBooster),
+            CaseWith(x => x.Morph.Grapple.PowerBomb),
+            CaseWith(x => x.Morph.HiJump),
+            CaseWith(x => x.Morph.Ice),
+        };
+
+        protected override List<Case> MissileBubbleNorfairGreenDoor => new() {
+            CaseWith(x => x.SpaceJump),
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Grapple.Morph.SpeedBooster),
+            CaseWith(x => x.Grapple.Morph.PowerBomb),
+            CaseWith(x => x.HiJump),
+            CaseWith(x => x.Ice),
+        };
+
+        protected override List<Case> MissileBubbleNorfair => CaseWithNothing;
+
+        protected override List<Case> MissileSpeedBooster => new() {
+            CaseWith(x => x.SpaceJump),
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.SpeedBooster),
+            CaseWith(x => x.Morph.PowerBomb),
+            CaseWith(x => x.HiJump),
+            CaseWith(x => x.Ice),
+        };
+        protected override List<Case> SpeedBooster => new() {
+            CaseWith(x => x.SpaceJump),
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.SpeedBooster),
+            CaseWith(x => x.Morph.PowerBomb),
+            CaseWith(x => x.HiJump),
+            CaseWith(x => x.Ice),
+        };
+
+        protected override List<Case> MissileWaveBeam => new() {
+            CaseWith(x => x.SpaceJump),
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.SpeedBooster),
+            CaseWith(x => x.Morph.PowerBomb),
+            CaseWith(x => x.HiJump),
+            CaseWith(x => x.Ice),
+        };
+
+        protected override List<Case> WaveBeam => new() {
+            CaseWith(x => x.Morph.SpaceJump),
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Morph.SpeedBooster),
+            CaseWith(x => x.Morph.PowerBomb),
+            CaseWith(x => x.Morph.HiJump),
+            CaseWith(x => x.Morph.Ice),
+        };
+
+        #endregion
+
+        #region Norfair Upper Crocomire
+
+        protected override List<Case> NorfairUpperCrocomire => new() {
+            CaseWith(x => x.Varia.Morph.Bombs.Super.Wave),
+            CaseWith(x => x.Varia.Morph.PowerBomb.Super.SpaceJump.Wave),
+            CaseWith(x => x.Varia.Morph.PowerBomb.Super.HiJump.Wave),
+            CaseWith(x => x.Varia.ScrewAttack.Super.Morph.SpaceJump.Gravity.Wave),
+            CaseWith(x => x.Varia.ScrewAttack.Super.Morph.HiJump.Gravity.Wave),
+            CaseWith(x => x.Varia.SpeedBooster.Super.Morph.PowerBomb),
+            CaseWith(x => x.Varia.SpeedBooster.Super.Morph.Wave),
+            CaseWith(x => x.Varia.Flute.SpeedBooster.Wave),
+            CaseWith(x => x.Varia.Flute.Super.SpaceJump.Gravity.Morph.Wave),
+            CaseWith(x => x.Varia.Flute.Super.HiJump.Gravity.Morph.Wave),
+            CaseWith(x => x.Varia.Glove.Lamp.SpeedBooster.Wave),
+            CaseWith(x => x.Varia.Glove.Lamp.Super.SpaceJump.Gravity.Morph.Wave),
+            CaseWith(x => x.Varia.Glove.Lamp.Super.HiJump.Gravity.Morph.Wave),
+            CaseWith(x => x.Varia.Flute.Mitt.ScrewAttack.SpaceJump.Super.Gravity.Wave),
+        };
+
+        protected override List<Case> EnergyTankCrocomire => new() {
+            CaseWith(x => x.Super.ETank(1)),
+            CaseWith(x => x.Super.SpaceJump),
+            CaseWith(x => x.Super.Grapple),
+        };
+
+        protected override List<Case> MissileAboveCrocomire => new() {
+            CaseWith(x => x.SpaceJump),
+            CaseWith(x => x.Morph.Bombs),
+            CaseWith(x => x.Grapple),
+            CaseWith(x => x.HiJump.SpeedBooster),
+        };
+
+        protected override List<Case> PowerBombCrocomire => new() {
+            CaseWith(x => x.Super.SpaceJump),
+            CaseWith(x => x.Super.Morph.Bombs),
+            CaseWith(x => x.Super.HiJump),
+            CaseWith(x => x.Super.Grapple),
+        };
+
+        protected override List<Case> MissileBelowCrocomire => new() {
+            CaseWith(x => x.Super.Morph),
+        };
+
+        protected override List<Case> MissileGrapplingBeam => new() {
+            CaseWith(x => x.Super.Morph.SpaceJump),
+            CaseWith(x => x.Super.Morph.Bombs),
+            CaseWith(x => x.Super.Morph.SpeedBooster.PowerBomb),
+        };
+        protected override List<Case> GrapplingBeam => new() {
+            CaseWith(x => x.Super.Morph.SpaceJump),
+            CaseWith(x => x.Super.Morph.Bombs),
+            CaseWith(x => x.Super.Morph.SpeedBooster.PowerBomb),
+        };
+
+        #endregion
+
+        #region Norfair Lower West
+
+        protected override List<Case> NorfairLowerWest => new() {
+            CaseWith(x => x.Varia.Morph.PowerBomb.Super.SpaceJump.Gravity),
+            CaseWith(x => x.Varia.Flute.Mitt.Morph.Bombs),
+            CaseWith(x => x.Varia.Flute.Mitt.Morph.PowerBomb),
+            CaseWith(x => x.Varia.Flute.Mitt.ScrewAttack),
+        };
+
+        protected override List<Case> MissileGoldTorizo => new() {
+            CaseWith(x => x.Morph.PowerBomb.SpaceJump.Super),
+        };
+
+        protected override List<Case> SuperMissileGoldTorizo => new() {
+            CaseWith(x => x.Morph.Bombs.Super.Flute.Mitt),
+            CaseWith(x => x.Morph.Bombs.Charge.Flute.Mitt),
+            CaseWith(x => x.Morph.PowerBomb.Super.Flute.Mitt),
+            CaseWith(x => x.Morph.PowerBomb.Super.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Charge.Flute.Mitt),
+            CaseWith(x => x.Morph.PowerBomb.Charge.SpaceJump),
+            CaseWith(x => x.ScrewAttack.Super.Flute.Mitt),
+            CaseWith(x => x.ScrewAttack.Charge.Flute.Mitt),
+        };
+
+        protected override List<Case> ScrewAttack => new() {
+            CaseWith(x => x.Morph.Bombs.Flute.Mitt),
+            CaseWith(x => x.Morph.PowerBomb.Flute.Mitt),
+            CaseWith(x => x.Morph.PowerBomb.SpaceJump),
+            CaseWith(x => x.ScrewAttack.Flute.Mitt),
+        };
+
+        protected override List<Case> MissileMickeyMouseRoom => new() {
+            CaseWith(x => x.Morph.Super.SpaceJump.PowerBomb),
+            CaseWith(x => x.Morph.Super.Bombs.PowerBomb),
+        };
+
+        #endregion
+
+        #region Norfair Lower East
+
+        protected override List<Case> NorfairLowerEast => new() {
+            CaseWith(x => x.Varia.Morph.PowerBomb.Super.SpaceJump.Gravity),
+            CaseWith(x => x.Varia.Flute.Mitt.Morph.PowerBomb.Super.SpaceJump),
+            CaseWith(x => x.Varia.Flute.Mitt.Morph.PowerBomb.Super.Bombs),
+        };
+
+        protected override List<Case> MissileLowerNorfairAboveFireFleaRoom => new() {
+            CaseWith(x => x.Morph),
+        };
+        protected override List<Case> PowerBombLowerNorfairAboveFireFleaRoom => new() {
+            CaseWith(x => x.Morph),
+        };
+
+        protected override List<Case> PowerBombPowerBombsOfShame => new() {
+            CaseWith(x => x.Morph.PowerBomb),
+        };
+
+        protected override List<Case> MissileLowerNorfairNearWaveBeam => new() {
+            CaseWith(x => x.Morph),
+        };
+
+        protected override List<Case> EnergyTankRidley => new() {
+            CaseWith(x => x.Morph.PowerBomb.Super),
+        };
+
+        protected override List<Case> EnergyTankFirefleas => new() {
+            CaseWith(x => x.Morph),
+        };
+
+        #endregion
+
+        #region Light World Death Mountain West
+
+        protected override List<Case> LightWorldDeathMountainWest => new() {
+            CaseWith(x => x.Flute),
+            CaseWith(x => x.Glove.Lamp),
+            CaseWith(x => x.Morph.Bombs.Super),
+            CaseWith(x => x.Morph.PowerBomb.Super),
+            CaseWith(x => x.ScrewAttack.Super.Morph),
+            CaseWith(x => x.SpeedBooster.Super.Morph),
+        };
+
+        protected override List<Case> EtherTablet => new() {
+            CaseWith(x => x.Book.MasterSword.Mirror),
+            CaseWith(x => x.Book.MasterSword.Hammer.Hookshot),
+        };
+
+        protected override List<Case> SpectacleRock => new() {
+            CaseWith(x => x.Mirror),
+        };
+
+        protected override List<Case> SpectacleRockCave => CaseWithNothing;
+
+        protected override List<Case> OldMan => new() {
+            CaseWith(x => x.Lamp),
+        };
+
+        #endregion
+
+        #region Light World Death Mountain East
+
+        protected override List<Case> LightWorldDeathMountainEast => new() {
+            CaseWith(x => x.Flute.Hammer.Mirror),
+            CaseWith(x => x.Flute.Hookshot),
+            CaseWith(x => x.Glove.Lamp.Hammer.Mirror),
+            CaseWith(x => x.Glove.Lamp.Hookshot),
+            CaseWith(x => x.Morph.Bombs.Super.Hammer.Mirror),
+            CaseWith(x => x.Morph.Bombs.Super.Hookshot),
+            CaseWith(x => x.Morph.PowerBomb.Super.Hammer.Mirror),
+            CaseWith(x => x.Morph.PowerBomb.Super.Hookshot),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Hammer.Mirror),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Hookshot),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Hammer.Mirror),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Hookshot),
+        };
+
+        protected override List<Case> FloatingIsland => new() {
+            CaseWith(x => x.Mirror.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> SpiralCave => CaseWithNothing;
+        protected override List<Case> ParadoxCave => CaseWithNothing;
+
+        protected override List<Case> MimicCave => new() {
+            CaseWith(x => x.Mirror.KeyTR(2).Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.Flute),
+            CaseWith(x => x.Mirror.KeyTR(2).Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.Lamp),
+            CaseWith(x => x.Mirror.KeyTR(2).Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.Morph.Bombs.Super),
+            CaseWith(x => x.Mirror.KeyTR(2).Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.Morph.PowerBomb.Super),
+            CaseWith(x => x.Mirror.KeyTR(2).Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.ScrewAttack.Super.Morph),
+            CaseWith(x => x.Mirror.KeyTR(2).Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.SpeedBooster.Super.Morph),
+        };
+
+        #endregion
+
+        #region Light World North West
+
+        protected override List<Case> LightWorldNorthWest => CaseWithNothing;
+
+        // Assumes prizes can be acquired
+        protected override List<Case> MasterSwordPedestal => CaseWithNothing;
+
+        protected override List<Case> Mushroom => CaseWithNothing;
+        protected override List<Case> LostWoodsHideout => CaseWithNothing;
+
+        protected override List<Case> LumberjackTree => new() {
+            CaseWith(x => x.Sword.Cape.Lamp.KeyCT(2).Boots),
+            CaseWith(x => x.MasterSword.Lamp.KeyCT(2).Boots),
+        };
+
+        protected override List<Case> PegasusRocks => new() {
+            CaseWith(x => x.Boots),
+        };
+
+        protected override List<Case> GraveyardLedge => new() {
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> KingsTomb => new() {
+            CaseWith(x => x.Boots.Mitt),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Hammer.Glove),
+        };
+
+        protected override List<Case> KakarikoWell => CaseWithNothing;
+        protected override List<Case> BlindsHideout => CaseWithNothing;
+        protected override List<Case> BottleMerchant => CaseWithNothing;
+        protected override List<Case> ChickenHouse => CaseWithNothing;
+
+        protected override List<Case> SickKid => new() {
+            CaseWith(x => x.Bottle),
+        };
+
+        protected override List<Case> KakarikoTavern => CaseWithNothing;
+
+        protected override List<Case> MagicBat => new() {
+            CaseWith(x => x.Powder.Hammer),
+            CaseWith(x => x.Powder.MoonPearl.Mirror.Mitt),
+        };
+
+        #endregion
+
+        #region Light World North East
+
+        protected override List<Case> LightWorldNorthEast => CaseWithNothing;
+
+        protected override List<Case> KingZora => new() {
+            CaseWith(x => x.Glove),
+            CaseWith(x => x.Flippers),
+        };
+
+        protected override List<Case> ZorasLedge => new() {
+            CaseWith(x => x.Flippers),
+        };
+        protected override List<Case> WaterfallFairy => new() {
+            CaseWith(x => x.Flippers),
+        };
+
+        protected override List<Case> PotionShop => new() {
+            CaseWith(x => x.Mushroom),
+        };
+
+        protected override List<Case> SahasrahlasHut => CaseWithNothing;
+
+        // Assumes prize can be acquired
+        protected override List<Case> Sahasrahla => CaseWithNothing;
+
+        #endregion
+
+        #region Light World South
+
+        protected override List<Case> LightWorldSouth => CaseWithNothing;
+
+        protected override List<Case> MazeRace => CaseWithNothing;
+
+        protected override List<Case> Library => new() {
+            CaseWith(x => x.Boots),
+        };
+
+        protected override List<Case> FluteSpot => new() {
+            CaseWith(x => x.Shovel),
+        };
+
+        protected override List<Case> SouthOfGrove => new() {
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> LinksHouse => CaseWithNothing;
+        protected override List<Case> AginahsCave => CaseWithNothing;
+        protected override List<Case> MiniMoldormCave => CaseWithNothing;
+
+        protected override List<Case> DesertLedge => DesertPalace;
+
+        protected override List<Case> CheckerboardCave => new() {
+            CaseWith(x => x.Mirror.Flute.Mitt),
+            CaseWith(x => x.Mirror.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Glove),
+        };
+
+        protected override List<Case> BombosTablet => new() {
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> FloodgateChest => CaseWithNothing;
+        protected override List<Case> SunkenTreasure => CaseWithNothing;
+
+        protected override List<Case> LakeHyliaIsland => new() {
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Hammer.Glove),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Mitt),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Morph.PowerBomb.Super.Gravity.SpeedBooster),
+        };
+
+        protected override List<Case> Hobo => new() {
+            CaseWith(x => x.Flippers),
+        };
+
+        protected override List<Case> IceRodCave => CaseWithNothing;
+
+        #endregion
+
+        #region Dark World Death Mountain West
+
+        protected override List<Case> DarkWorldDeathMountainWest => CaseWithNothing;
+
+        protected override List<Case> SpikeCave => new() {
+            CaseWith(x => x.MoonPearl.Hammer.Glove.HalfMagic.Cape.Flute),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.HalfMagic.Cape.Lamp),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.HalfMagic.Cape.Morph.Bombs.Super),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.HalfMagic.Cape.Morph.PowerBomb.Super),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.HalfMagic.Cape.ScrewAttack.Super.Morph),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.HalfMagic.Cape.SpeedBooster.Super.Morph),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.Bottle.Cape.Flute),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.Bottle.Cape.Lamp),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.Bottle.Cape.Morph.Bombs.Super),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.Bottle.Cape.Morph.PowerBomb.Super),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.Bottle.Cape.ScrewAttack.Super.Morph),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.Bottle.Cape.SpeedBooster.Super.Morph),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.Byrna.Flute),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.Byrna.Lamp),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.Byrna.Morph.Bombs.Super),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.Byrna.Morph.PowerBomb.Super),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.Byrna.ScrewAttack.Super.Morph),
+            CaseWith(x => x.MoonPearl.Hammer.Glove.Byrna.SpeedBooster.Super.Morph),
+        };
+
+        #endregion
+
+        #region Dark World Death Mountain East
+
+        protected override List<Case> DarkWorldDeathMountainEast => new() {
+            CaseWith(x => x.Mitt.Flute.Hammer.Mirror),
+            CaseWith(x => x.Mitt.Flute.Hookshot),
+            CaseWith(x => x.Mitt.Lamp.Hammer.Mirror),
+            CaseWith(x => x.Mitt.Lamp.Hookshot),
+            CaseWith(x => x.Mitt.Morph.Bombs.Super.Hammer.Mirror),
+            CaseWith(x => x.Mitt.Morph.Bombs.Super.Hookshot),
+            CaseWith(x => x.Mitt.Morph.PowerBomb.Super.Hammer.Mirror),
+            CaseWith(x => x.Mitt.Morph.PowerBomb.Super.Hookshot),
+            CaseWith(x => x.Mitt.ScrewAttack.Super.Morph.Hammer.Mirror),
+            CaseWith(x => x.Mitt.ScrewAttack.Super.Morph.Hookshot),
+            CaseWith(x => x.Mitt.SpeedBooster.Super.Morph.Hammer.Mirror),
+            CaseWith(x => x.Mitt.SpeedBooster.Super.Morph.Hookshot),
+        };
+
+        protected override List<Case> HookshotCave => new() {
+            CaseWith(x => x.MoonPearl.Hookshot),
+        };
+
+        protected override List<Case> HookshotCaveBottomRight => new() {
+            CaseWith(x => x.MoonPearl.Hookshot),
+            CaseWith(x => x.MoonPearl.Boots),
+        };
+
+        protected override List<Case> SuperbunnyCave => new() {
+            CaseWith(x => x.MoonPearl),
+        };
+
+        #endregion
+
+        #region Dark World North West
+
+        protected override List<Case> DarkWorldNorthWest => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> BumperCave => new() {
+            CaseWith(x => x.Glove.Cape),
+        };
+
+        protected override List<Case> VillageOfOutcasts => CaseWithNothing;
+
+        protected override List<Case> HammerPegs => new() {
+            CaseWith(x => x.Mitt.Hammer),
+        };
+
+        protected override List<Case> Blacksmith => new() {
+            CaseWith(x => x.Mitt),
+        };
+        protected override List<Case> PurpleChest => new() {
+            CaseWith(x => x.Mitt),
+        };
+
+        #endregion
+
+        #region Dark World North East
+
+        protected override List<Case> DarkWorldNorthEast => new() {
+            CaseWith(x => x.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers),
+        };
+
+        protected override List<Case> Catfish => new() {
+            CaseWith(x => x.MoonPearl.Glove),
+        };
+
+        protected override List<Case> Pyramid => CaseWithNothing;
+
+        // Assumes prizes can be acquired
+        protected override List<Case> PyramidFairy => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers.Mirror),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove.Mirror),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers.Mirror),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove.Mirror),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt.Mirror.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Mitt.Mirror.MasterSword.Lamp.KeyCT(2)),
+        };
+
+        #endregion
+
+        #region Dark World South
+
+        protected override List<Case> DarkWorldSouth => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> DiggingGame => CaseWithNothing;
+        protected override List<Case> Stumpy => CaseWithNothing;
+        protected override List<Case> HypeCave => CaseWithNothing;
+
+        #endregion
+
+        #region Dark World Mire
+
+        protected override List<Case> DarkWorldMire => new() {
+            CaseWith(x => x.Flute.Mitt),
+            CaseWith(x => x.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb),
+        };
+
+        protected override List<Case> MireShed => new() {
+            CaseWith(x => x.MoonPearl),
+        };
+
+        #endregion
+
+        #region Hyrule Castle
+
+        protected override List<Case> HyruleCastle => CaseWithNothing;
+
+        protected override List<Case> Sanctuary => CaseWithNothing;
+
+        protected override List<Case> SewersSecretRoom => new() {
+            CaseWith(x => x.Glove),
+            CaseWith(x => x.Lamp.KeyHC(1)),
+        };
+
+        protected override List<Case> SewersDarkCross => new() {
+            CaseWith(x => x.Lamp),
+        };
+
+        protected override List<Case> HyruleCastleMapChest => CaseWithNothing;
+
+        protected override List<Case> HyruleCastleBoomerangChest => new() {
+            CaseWith(x => x.KeyHC(1)),
+        };
+        protected override List<Case> HyruleCastleZeldasCell => new() {
+            CaseWith(x => x.KeyHC(1)),
+        };
+
+        protected override List<Case> LinksUncle => CaseWithNothing;
+        protected override List<Case> SecretPassage => CaseWithNothing;
+
+        #endregion
+
+        #region Castle Tower
+
+        protected override List<Case> CastleTower => new() {
+            CaseWith(x => x.MasterSword),
+            CaseWith(x => x.Sword.Cape),
+            CaseWith(x => x.Hammer.Cape),
+            CaseWith(x => x.Bow.Cape),
+            CaseWith(x => x.Firerod.Cape),
+            CaseWith(x => x.Somaria.Cape),
+            CaseWith(x => x.HalfMagic.Byrna.Cape),
+            CaseWith(x => x.Bottle.Byrna.Cape),
+        };
+
+        protected override List<Case> CastleTowerFoyer => CaseWithNothing;
+
+        protected override List<Case> CastleTowerDarkMaze => new() {
+            CaseWith(x => x.Lamp.KeyCT(1)),
+        };
+
+        #endregion
+
+        #region Eastern Palace
+
+        protected override List<Case> EasternPalace => CaseWithNothing;
+
+        protected override List<Case> EasternPalaceCannonballChest => CaseWithNothing;
+        protected override List<Case> EasternPalaceMapChest => CaseWithNothing;
+        protected override List<Case> EasternPalaceCompassChest => CaseWithNothing;
+
+        protected override List<Case> EasternPalaceBigChest => new() {
+            CaseWith(x => x.BigKeyEP),
+        };
+
+        protected override List<Case> EasternPalaceBigKeyChest => new() {
+            CaseWith(x => x.Lamp),
+        };
+
+        protected override List<Case> EasternPalaceArmosKnights => new() {
+            CaseWith(x => x.BigKeyEP.Bow.Lamp),
+        };
+
+        #endregion
+
+        #region Desert Palace
+
+        protected override List<Case> DesertPalace => new() {
+            CaseWith(x => x.Book),
+            CaseWith(x => x.Mirror.Mitt.Flute),
+            CaseWith(x => x.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror),
+        };
+
+        protected override List<Case> DesertPalaceBigChest => new() {
+            CaseWith(x => x.BigKeyDP),
+        };
+
+        protected override List<Case> DesertPalaceTorch => new() {
+            CaseWith(x => x.Boots),
+        };
+
+        protected override List<Case> DesertPalaceMapChest => CaseWithNothing;
+
+        protected override List<Case> DesertPalaceBigKeyChest => new() {
+            CaseWith(x => x.KeyDP(1)),
+        };
+        protected override List<Case> DesertPalaceCompassChest => new() {
+            CaseWith(x => x.KeyDP(1)),
+        };
+
+        protected override List<Case> DesertPalaceLanmolas => new() {
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Firerod),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Lamp.Sword),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Lamp.Hammer),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Lamp.Bow),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Lamp.Icerod),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Lamp.Byrna),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP(1).Lamp.Somaria),
+            CaseWith(x => x.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Firerod),
+            CaseWith(x => x.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Sword),
+            CaseWith(x => x.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Hammer),
+            CaseWith(x => x.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Bow),
+            CaseWith(x => x.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Icerod),
+            CaseWith(x => x.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Byrna),
+            CaseWith(x => x.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP(1).Lamp.Somaria),
+        };
+
+        #endregion
+
+        #region Tower of Hera
+
+        protected override List<Case> TowerOfHera => new() {
+            CaseWith(x => x.Mirror.Flute),
+            CaseWith(x => x.Mirror.Glove.Lamp),
+            CaseWith(x => x.Mirror.Morph.Bombs.Super),
+            CaseWith(x => x.Mirror.Morph.PowerBomb.Super),
+            CaseWith(x => x.Mirror.ScrewAttack.Super.Morph),
+            CaseWith(x => x.Mirror.SpeedBooster.Super.Morph),
+            CaseWith(x => x.Hookshot.Hammer.Flute),
+            CaseWith(x => x.Hookshot.Hammer.Glove.Lamp),
+            CaseWith(x => x.Hookshot.Hammer.Morph.Bombs.Super),
+            CaseWith(x => x.Hookshot.Hammer.Morph.PowerBomb.Super),
+            CaseWith(x => x.Hookshot.Hammer.ScrewAttack.Super.Morph),
+            CaseWith(x => x.Hookshot.Hammer.SpeedBooster.Super.Morph),
+        };
+
+        protected override List<Case> TowerOfHeraBasementCage => CaseWithNothing;
+        protected override List<Case> TowerOfHeraMapChest => CaseWithNothing;
+
+        protected override List<Case> TowerOfHeraBigKeyChest => new() {
+            CaseWith(x => x.KeyTH(1).Firerod),
+            CaseWith(x => x.KeyTH(1).Lamp),
+        };
+
+        protected override List<Case> TowerOfHeraCompassChest => new() {
+            CaseWith(x => x.BigKeyTH),
+        };
+        protected override List<Case> TowerOfHeraBigChest => new() {
+            CaseWith(x => x.BigKeyTH),
+        };
+
+        protected override List<Case> TowerOfHeraMoldorm => new() {
+            CaseWith(x => x.BigKeyTH.Sword),
+            CaseWith(x => x.BigKeyTH.Hammer),
+        };
+
+        #endregion
+
+        #region Palace of Darkness
+
+        protected override List<Case> PalaceOfDarkness => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt.Flippers),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers),
+        };
+
+        protected override List<Case> PalaceOfDarknessShooterRoom => CaseWithNothing;
+
+        protected override List<Case> PalaceOfDarknessBigKeyChest => new() {
+            CaseWith(x => x.Has.KeyPD.KeyPD(1)),
+            CaseWith(x => x.IfSkipping.Hammer.Bow.Lamp.AlsoSkip.KeyPD(2).KeyPD(6)),
+            CaseWith(x => x.IfSkipping.Hammer.Bow.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.IfSkipping.Hammer.Lamp.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.IfSkipping.Hammer.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.IfSkipping.Bow.Lamp.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.IfSkipping.Bow.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.IfSkipping.Lamp.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.KeyPD(5)),
+        };
+
+        protected override List<Case> PalaceOfDarknessStalfosBasement => new() {
+            CaseWith(x => x.KeyPD(1)),
+            CaseWith(x => x.Bow.Hammer),
+        };
+        protected override List<Case> PalaceOfDarknessTheArenaBridge => new() {
+            CaseWith(x => x.KeyPD(1)),
+            CaseWith(x => x.Bow.Hammer),
+        };
+
+        protected override List<Case> PalaceOfDarknessTheArenaLedge => new() {
+            CaseWith(x => x.Bow),
+        };
+        protected override List<Case> PalaceOfDarknessMapChest => new() {
+            CaseWith(x => x.Bow),
+        };
+
+        protected override List<Case> PalaceOfDarknessCompassChest => new() {
+            CaseWith(x => x.IfSkipping.Hammer.Bow.Lamp.AlsoSkip.KeyPD(2).KeyPD(4)),
+            CaseWith(x => x.IfSkipping.Hammer.Bow.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.IfSkipping.Hammer.Lamp.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.IfSkipping.Hammer.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.IfSkipping.Bow.Lamp.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.IfSkipping.Bow.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.IfSkipping.Lamp.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.KeyPD(3)),
+        };
+
+        protected override List<Case> PalaceOfDarknessHarmlessHellway => new() {
+            CaseWith(x => x.Has.KeyPD.IfSkipping.Hammer.Bow.Lamp.AlsoSkip.KeyPD(2).KeyPD(4)),
+            CaseWith(x => x.Has.KeyPD.IfSkipping.Hammer.Bow.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.Has.KeyPD.IfSkipping.Hammer.Lamp.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.Has.KeyPD.IfSkipping.Bow.Lamp.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.Has.KeyPD.IfSkipping.Hammer.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.Has.KeyPD.IfSkipping.Bow.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.Has.KeyPD.IfSkipping.Lamp.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.Has.KeyPD.KeyPD(3)),
+            CaseWith(x => x.IfSkipping.Hammer.Bow.Lamp.AlsoSkip.KeyPD(2).KeyPD(6)),
+            CaseWith(x => x.IfSkipping.Hammer.Bow.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.IfSkipping.Hammer.Lamp.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.IfSkipping.Bow.Lamp.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.IfSkipping.Hammer.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.IfSkipping.Bow.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.IfSkipping.Lamp.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.KeyPD(5)),
+        };
+
+        protected override List<Case> PalaceOfDarknessDarkBasement => new() {
+            CaseWith(x => x.Lamp.IfSkipping.Hammer.Bow.AlsoSkip.KeyPD(2).KeyPD(4)),
+            CaseWith(x => x.Lamp.IfSkipping.Hammer.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.Lamp.IfSkipping.Bow.AlsoSkip.KeyPD(1).KeyPD(3)),
+            CaseWith(x => x.Lamp.KeyPD(3)),
+        };
+
+        protected override List<Case> PalaceOfDarknessDarkMaze => new() {
+            CaseWith(x => x.Lamp.IfSkipping.Hammer.Bow.AlsoSkip.KeyPD(2).KeyPD(6)),
+            CaseWith(x => x.Lamp.IfSkipping.Hammer.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.Lamp.IfSkipping.Bow.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.Lamp.KeyPD(5)),
+        };
+
+        protected override List<Case> PalaceOfDarknessBigChest => new() {
+            CaseWith(x => x.BigKeyPD.Lamp.IfSkipping.Hammer.Bow.AlsoSkip.KeyPD(2).KeyPD(6)),
+            CaseWith(x => x.BigKeyPD.Lamp.IfSkipping.Hammer.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.BigKeyPD.Lamp.IfSkipping.Bow.AlsoSkip.KeyPD(1).KeyPD(5)),
+            CaseWith(x => x.BigKeyPD.Lamp.KeyPD(5)),
+        };
+
+        protected override List<Case> PalaceOfDarknessHelmasaurKing => new() {
+            CaseWith(x => x.Lamp.Hammer.Bow.BigKeyPD.KeyPD(6)),
+        };
+
+        #endregion
+
+        #region Swamp Palace
+
+        protected override List<Case> SwampPalace => new() {
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Sword.Cape.Lamp.KeyCT(2).Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.MasterSword.Lamp.KeyCT(2).Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Gravity.SpeedBooster.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Morph.PowerBomb.Super.Gravity.SpeedBooster.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Mitt),
+        };
+
+        protected override List<Case> SwampPalaceEntrance => CaseWithNothing;
+
+        protected override List<Case> SwampPalaceMapChest => new() {
+            CaseWith(x => x.KeySP(1)),
+        };
+
+        protected override List<Case> SwampPalaceBigChest => new() {
+            CaseWith(x => x.BigKeySP.KeySP(1).Hammer),
+        };
+
+        protected override List<Case> SwampPalaceCompassChest => new() {
+            CaseWith(x => x.KeySP(1).Hammer),
+        };
+        protected override List<Case> SwampPalaceWestWing => new() {
+            CaseWith(x => x.KeySP(1).Hammer),
+        };
+
+        protected override List<Case> SwampPalaceFloodedRoom => new() {
+            CaseWith(x => x.KeySP(1).Hammer.Hookshot),
+        };
+        protected override List<Case> SwampPalaceWaterfallRoom => new() {
+            CaseWith(x => x.KeySP(1).Hammer.Hookshot),
+        };
+
+        protected override List<Case> SwampPalaceArrghus => new() {
+            CaseWith(x => x.KeySP(1).Hammer.Hookshot),
+        };
+
+        #endregion
+
+        #region Skull Woods
+
+        protected override List<Case> SkullWoods => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> SkullWoodsPotPrison => CaseWithNothing;
+        protected override List<Case> SkullWoodsCompassChest => CaseWithNothing;
+
+        protected override List<Case> SkullWoodsBigChest => new() {
+            CaseWith(x => x.BigKeySW),
+        };
+
+        protected override List<Case> SkullWoodsMapChest => CaseWithNothing;
+        // Skipping "Skull Woods - Pinball Room" since it is always a key
+        protected override List<Case> SkullWoodsBigKeyChest => CaseWithNothing;
+
+        protected override List<Case> SkullWoodsBridgeRoom => new() {
+            CaseWith(x => x.Firerod),
+        };
+
+        protected override List<Case> SkullWoodsMothula => new() {
+            CaseWith(x => x.Firerod.Sword.KeySW(3)),
+        };
+
+        #endregion
+
+        #region Thieves' Town
+
+        protected override List<Case> ThievesTown => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> ThievesTownCourtyard => CaseWithNothing;
+
+        protected override List<Case> ThievesTownAttic => new() {
+            CaseWith(x => x.BigKeyTT.KeyTT(1)),
+        };
+
+        protected override List<Case> ThievesTownBlindsCell => new() {
+            CaseWith(x => x.BigKeyTT),
+        };
+
+        protected override List<Case> ThievesTownBigChest => new() {
+            CaseWith(x => x.BigKeyTT.Hammer.Has.KeyTT),
+            CaseWith(x => x.BigKeyTT.Hammer.KeyTT(1)),
+        };
+
+        protected override List<Case> ThievesTownBlind => new() {
+            CaseWith(x => x.BigKeyTT.KeyTT(1).Sword),
+            CaseWith(x => x.BigKeyTT.KeyTT(1).Hammer),
+            CaseWith(x => x.BigKeyTT.KeyTT(1).Somaria),
+            CaseWith(x => x.BigKeyTT.KeyTT(1).Byrna),
+        };
+
+        #endregion
+
+        #region Ice Palace
+
+        protected override List<Case> IcePalace => new() {
+            CaseWith(x => x.MoonPearl.Flippers.Mitt.Firerod),
+            CaseWith(x => x.MoonPearl.Flippers.Mitt.Bombos.Sword),
+        };
+
+        protected override List<Case> IcePalaceCompassChest => CaseWithNothing;
+
+        protected override List<Case> IcePalaceSpikeRoom => new() {
+            CaseWith(x => x.Hookshot),
+            CaseWith(x => x.KeyIP(1)),
+            CaseWith(x => x.KeyIP(1).Assume.BigKeyIP.HasAt("Ice Palace - Map Chest").BigKeyIP),
+            CaseWith(x => x.KeyIP(1).Assume.BigKeyIP.HasAt("Ice Palace - Big Key Chest").BigKeyIP),
+        };
+
+        protected override List<Case> IcePalaceMapChest => new() {
+            CaseWith(x => x.Hammer.Glove.Hookshot),
+            CaseWith(x => x.Hammer.Glove.KeyIP(1)),
+            CaseWith(x => x.Hammer.Glove.KeyIP(1).Assume.BigKeyIP.HasAt("Ice Palace - Spike Room").BigKeyIP),
+            CaseWith(x => x.Hammer.Glove.KeyIP(1).Assume.BigKeyIP.HasAt("Ice Palace - Big Key Chest").BigKeyIP),
+        };
+
+        protected override List<Case> IcePalaceBigKeyChest => new() {
+            CaseWith(x => x.Hammer.Glove.Hookshot),
+            CaseWith(x => x.Hammer.Glove.KeyIP(1)),
+            CaseWith(x => x.Hammer.Glove.KeyIP(1).Assume.BigKeyIP.HasAt("Ice Palace - Spike Room").BigKeyIP),
+            CaseWith(x => x.Hammer.Glove.KeyIP(1).Assume.BigKeyIP.HasAt("Ice Palace - Map Chest").BigKeyIP),
+        };
+
+        protected override List<Case> IcePalaceIcedTRoom => CaseWithNothing;
+        protected override List<Case> IcePalaceFreezorChest => CaseWithNothing;
+
+        protected override List<Case> IcePalaceBigChest => new() {
+            CaseWith(x => x.BigKeyIP),
+        };
+
+        protected override List<Case> IcePalaceKholdstare => new() {
+            CaseWith(x => x.BigKeyIP.Hammer.Glove.Somaria.KeyIP(1)),
+            CaseWith(x => x.BigKeyIP.Hammer.Glove.KeyIP(2)),
+        };
+
+        #endregion
+
+        #region Misery Mire
+
+        protected override List<Case> MiseryMire => new() {
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.Flute.Mitt),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.Flute.Mitt),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb),
+        };
+
+        protected override List<Case> MiseryMireMainLobby => new() {
+            CaseWith(x => x.BigKeyMM),
+            CaseWith(x => x.KeyMM(1)),
+        };
+        protected override List<Case> MiseryMireMapChest => new() {
+            CaseWith(x => x.BigKeyMM),
+            CaseWith(x => x.KeyMM(1)),
+        };
+
+        protected override List<Case> MiseryMireBridgeChest => CaseWithNothing;
+        protected override List<Case> MiseryMireSpikeChest => CaseWithNothing;
+
+        protected override List<Case> MiseryMireCompassChest => new() {
+            CaseWith(x => x.Firerod.KeyMM(2).HasAt("Misery Mire - Big Key Chest").BigKeyMM),
+            CaseWith(x => x.Firerod.KeyMM(3)),
+            CaseWith(x => x.Lamp.KeyMM(2).HasAt("Misery Mire - Big Key Chest").BigKeyMM),
+            CaseWith(x => x.Lamp.KeyMM(3)),
+        };
+
+        protected override List<Case> MiseryMireBigKeyChest => new() {
+            CaseWith(x => x.Firerod.KeyMM(2).HasAt("Misery Mire - Compass Chest").BigKeyMM),
+            CaseWith(x => x.Firerod.KeyMM(3)),
+            CaseWith(x => x.Lamp.KeyMM(2).HasAt("Misery Mire - Compass Chest").BigKeyMM),
+            CaseWith(x => x.Lamp.KeyMM(3)),
+        };
+
+        protected override List<Case> MiseryMireBigChest => new() {
+            CaseWith(x => x.BigKeyMM),
+        };
+
+        protected override List<Case> MiseryMireVitreous => new() {
+            CaseWith(x => x.BigKeyMM.Lamp.Somaria),
+        };
+
+        #endregion
+
+        #region Turtle Rock
+
+        protected override List<Case> TurtleRock => new() {
+            CaseWith(x => x.Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.Flute.Mirror),
+            CaseWith(x => x.Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.Flute.Hookshot),
+            CaseWith(x => x.Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.Lamp.Mirror),
+            CaseWith(x => x.Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.Lamp.Hookshot),
+            CaseWith(x => x.Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.Morph.Bombs.Super.Mirror),
+            CaseWith(x => x.Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.Morph.Bombs.Super.Hookshot),
+            CaseWith(x => x.Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.Morph.PowerBomb.Super.Mirror),
+            CaseWith(x => x.Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.Morph.PowerBomb.Super.Hookshot),
+            CaseWith(x => x.Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.ScrewAttack.Super.Morph.Mirror),
+            CaseWith(x => x.Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.ScrewAttack.Super.Morph.Hookshot),
+            CaseWith(x => x.Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.SpeedBooster.Super.Morph.Mirror),
+            CaseWith(x => x.Quake.Sword.MoonPearl.Mitt.Hammer.Somaria.SpeedBooster.Super.Morph.Hookshot),
+        };
+
+        protected override List<Case> TurtleRockCompassChest => CaseWithNothing;
+
+        protected override List<Case> TurtleRockRollerRoom => new() {
+            CaseWith(x => x.Firerod),
+        };
+
+        protected override List<Case> TurtleRockChainChomps => new() {
+            CaseWith(x => x.KeyTR(1)),
+        };
+
+        protected override List<Case> TurtleRockBigKeyChest => new() {
+            CaseWith(x => x.KeyTR(2)),
+        };
+
+        protected override List<Case> TurtleRockBigChest => new() {
+            CaseWith(x => x.BigKeyTR.KeyTR(2)),
+        };
+        protected override List<Case> TurtleRockCrystarollerRoom => new() {
+            CaseWith(x => x.BigKeyTR.KeyTR(2)),
+        };
+
+        protected override List<Case> TurtleRockEyeBridge => new() {
+            CaseWith(x => x.BigKeyTR.KeyTR(3).Lamp.Cape),
+            CaseWith(x => x.BigKeyTR.KeyTR(3).Lamp.Byrna),
+            CaseWith(x => x.BigKeyTR.KeyTR(3).Lamp.MirrorShield),
+        };
+
+        protected override List<Case> TurtleRockTrinexx => new() {
+            CaseWith(x => x.BigKeyTR.KeyTR(4).Lamp.Firerod.Icerod),
+        };
+
+        #endregion
+
+        #region Ganon's Tower
+
+        // Assumes prizes can be acquired
+        protected override List<Case> GanonsTower => new() {
+            CaseWith(x => x.MoonPearl.Mitt.Flute.Hammer.Mirror),
+            CaseWith(x => x.MoonPearl.Mitt.Flute.Hookshot),
+            CaseWith(x => x.MoonPearl.Mitt.Lamp.Hammer.Mirror),
+            CaseWith(x => x.MoonPearl.Mitt.Lamp.Hookshot),
+            CaseWith(x => x.MoonPearl.Mitt.Morph.Bombs.Super.Hammer.Mirror),
+            CaseWith(x => x.MoonPearl.Mitt.Morph.Bombs.Super.Hookshot),
+            CaseWith(x => x.MoonPearl.Mitt.Morph.PowerBomb.Super.Hammer.Mirror),
+            CaseWith(x => x.MoonPearl.Mitt.Morph.PowerBomb.Super.Hookshot),
+            CaseWith(x => x.MoonPearl.Mitt.ScrewAttack.Super.Morph.Hammer.Mirror),
+            CaseWith(x => x.MoonPearl.Mitt.ScrewAttack.Super.Morph.Hookshot),
+            CaseWith(x => x.MoonPearl.Mitt.SpeedBooster.Super.Morph.Hammer.Mirror),
+            CaseWith(x => x.MoonPearl.Mitt.SpeedBooster.Super.Morph.Hookshot),
+        };
+
+        protected override List<Case> GanonsTowerBobsTorch => new() {
+            CaseWith(x => x.Boots),
+        };
+
+        protected override List<Case> GanonsTowerDMsRoom => new() {
+            CaseWith(x => x.Hammer.Hookshot),
+        };
+
+        protected override List<Case> GanonsTowerMapChest => new() {
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).Has.BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).Has.KeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(4)),
+            CaseWith(x => x.Hammer.Boots.KeyGT(3).Has.BigKeyGT),
+            CaseWith(x => x.Hammer.Boots.KeyGT(3).Has.KeyGT),
+            CaseWith(x => x.Hammer.Boots.KeyGT(4)),
+        };
+
+        protected override List<Case> GanonsTowerFiresnakeRoom => new() {
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(2).HasAt("Ganon's Tower - Randomizer Room - Top Left").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(2).HasAt("Ganon's Tower - Randomizer Room - Top Right").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(2).HasAt("Ganon's Tower - Randomizer Room - Bottom Left").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(2).HasAt("Ganon's Tower - Randomizer Room - Bottom Right").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(2).Has.KeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3)),
+        };
+
+        protected override List<Case> GanonsTowerRandomizerRoomTopLeft => new() {
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).HasAt("Ganon's Tower - Randomizer Room - Top Right").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).HasAt("Ganon's Tower - Randomizer Room - Bottom Left").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).HasAt("Ganon's Tower - Randomizer Room - Bottom Right").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(4)),
+        };
+        protected override List<Case> GanonsTowerRandomizerRoomTopRight => new() {
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).HasAt("Ganon's Tower - Randomizer Room - Top Left").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).HasAt("Ganon's Tower - Randomizer Room - Bottom Left").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).HasAt("Ganon's Tower - Randomizer Room - Bottom Right").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(4)),
+        };
+        protected override List<Case> GanonsTowerRandomizerRoomBottomLeft => new() {
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).HasAt("Ganon's Tower - Randomizer Room - Top Right").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).HasAt("Ganon's Tower - Randomizer Room - Top Left").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).HasAt("Ganon's Tower - Randomizer Room - Bottom Right").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(4)),
+        };
+        protected override List<Case> GanonsTowerRandomizerRoomBottomRight => new() {
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).HasAt("Ganon's Tower - Randomizer Room - Top Left").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).HasAt("Ganon's Tower - Randomizer Room - Top Right").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(3).HasAt("Ganon's Tower - Randomizer Room - Bottom Left").BigKeyGT),
+            CaseWith(x => x.Hammer.Hookshot.KeyGT(4)),
+        };
+
+        protected override List<Case> GanonsTowerHopeRoom => CaseWithNothing;
+
+        protected override List<Case> GanonsTowerTileRoom => new() {
+            CaseWith(x => x.Somaria),
+        };
+
+        protected override List<Case> GanonsTowerCompassRoomTopLeft => new() {
+            CaseWith(x => x.Somaria.Firerod.KeyGT(3).HasAt("Ganon's Tower - Compass Room - Top Right").BigKeyGT),
+            CaseWith(x => x.Somaria.Firerod.KeyGT(3).HasAt("Ganon's Tower - Compass Room - Bottom Left").BigKeyGT),
+            CaseWith(x => x.Somaria.Firerod.KeyGT(3).HasAt("Ganon's Tower - Compass Room - Bottom Right").BigKeyGT),
+            CaseWith(x => x.Somaria.Firerod.KeyGT(4)),
+        };
+        protected override List<Case> GanonsTowerCompassRoomTopRight => new() {
+            CaseWith(x => x.Somaria.Firerod.KeyGT(3).HasAt("Ganon's Tower - Compass Room - Top Left").BigKeyGT),
+            CaseWith(x => x.Somaria.Firerod.KeyGT(3).HasAt("Ganon's Tower - Compass Room - Bottom Left").BigKeyGT),
+            CaseWith(x => x.Somaria.Firerod.KeyGT(3).HasAt("Ganon's Tower - Compass Room - Bottom Right").BigKeyGT),
+            CaseWith(x => x.Somaria.Firerod.KeyGT(4)),
+        };
+        protected override List<Case> GanonsTowerCompassRoomBottomLeft => new() {
+            CaseWith(x => x.Somaria.Firerod.KeyGT(3).HasAt("Ganon's Tower - Compass Room - Top Left").BigKeyGT),
+            CaseWith(x => x.Somaria.Firerod.KeyGT(3).HasAt("Ganon's Tower - Compass Room - Top Right").BigKeyGT),
+            CaseWith(x => x.Somaria.Firerod.KeyGT(3).HasAt("Ganon's Tower - Compass Room - Bottom Right").BigKeyGT),
+            CaseWith(x => x.Somaria.Firerod.KeyGT(4)),
+        };
+        protected override List<Case> GanonsTowerCompassRoomBottomRight => new() {
+            CaseWith(x => x.Somaria.Firerod.KeyGT(3).HasAt("Ganon's Tower - Compass Room - Top Left").BigKeyGT),
+            CaseWith(x => x.Somaria.Firerod.KeyGT(3).HasAt("Ganon's Tower - Compass Room - Top Right").BigKeyGT),
+            CaseWith(x => x.Somaria.Firerod.KeyGT(3).HasAt("Ganon's Tower - Compass Room - Bottom Left").BigKeyGT),
+            CaseWith(x => x.Somaria.Firerod.KeyGT(4)),
+        };
+
+        protected override List<Case> GanonsTowerBobsChest => new() {
+            CaseWith(x => x.KeyGT(3).Hammer.Hookshot),
+            CaseWith(x => x.KeyGT(3).Somaria.Firerod),
+        };
+
+        protected override List<Case> GanonsTowerBigChest => new() {
+            CaseWith(x => x.BigKeyGT.KeyGT(3).Hammer.Hookshot),
+            CaseWith(x => x.BigKeyGT.KeyGT(3).Somaria.Firerod),
+        };
+
+        protected override List<Case> GanonsTowerBigKeyRoom => new() {
+            CaseWith(x => x.KeyGT(3).Hammer.Hookshot),
+            CaseWith(x => x.KeyGT(3).Firerod.Somaria.Sword),
+            CaseWith(x => x.KeyGT(3).Firerod.Somaria.Hammer),
+            CaseWith(x => x.KeyGT(3).Firerod.Somaria.Bow),
+            CaseWith(x => x.KeyGT(3).Firerod.Somaria.HalfMagic),
+            CaseWith(x => x.KeyGT(3).Firerod.Somaria.Bottle),
+        };
+
+        protected override List<Case> GanonsTowerAscent => new() {
+            CaseWith(x => x.BigKeyGT.KeyGT(3).Bow.Firerod),
+            CaseWith(x => x.BigKeyGT.KeyGT(3).Bow.Lamp),
+        };
+
+        protected override List<Case> GanonsTowerMoldormChest => new() {
+            CaseWith(x => x.BigKeyGT.KeyGT(4).Bow.Firerod.Sword.Hookshot),
+            CaseWith(x => x.BigKeyGT.KeyGT(4).Bow.Firerod.Hammer.Hookshot),
+            CaseWith(x => x.BigKeyGT.KeyGT(4).Bow.Lamp.Sword.Hookshot),
+            CaseWith(x => x.BigKeyGT.KeyGT(4).Bow.Lamp.Hammer.Hookshot),
+        };
+
+        #endregion
+
+    }
+
+}

--- a/Randomizer.SMZ3.Tests/Logic/SMNormalKeysanity.cs
+++ b/Randomizer.SMZ3.Tests/Logic/SMNormalKeysanity.cs
@@ -1,0 +1,910 @@
+﻿using System.Collections.Generic;
+
+namespace Randomizer.SMZ3.Tests.Logic {
+
+    public class SMNormalKeysanity : SMNormal {
+
+        #region Crateria West
+
+        protected override List<Case> EnergyTankGauntlet => new() {
+            CaseWith(x => x.CardCrateriaL1.Morph.Bombs.ETank(1)),
+            CaseWith(x => x.CardCrateriaL1.Morph.SpaceJump.TwoPowerBombs.ETank(1)),
+            CaseWith(x => x.CardCrateriaL1.Morph.SpaceJump.ScrewAttack.ETank(1)),
+            CaseWith(x => x.CardCrateriaL1.Morph.SpeedBooster.TwoPowerBombs.ETank(1)),
+            CaseWith(x => x.CardCrateriaL1.Morph.SpeedBooster.ScrewAttack.ETank(1)),
+        };
+
+        protected override List<Case> MissileCrateriaGauntlet => new() {
+            CaseWith(x => x.CardCrateriaL1.Morph.Bombs.ETank(2)),
+            CaseWith(x => x.CardCrateriaL1.Morph.SpaceJump.TwoPowerBombs.ETank(2)),
+            CaseWith(x => x.CardCrateriaL1.Morph.SpaceJump.ScrewAttack.PowerBomb.ETank(2)),
+            CaseWith(x => x.CardCrateriaL1.Morph.SpeedBooster.TwoPowerBombs.ETank(2)),
+            CaseWith(x => x.CardCrateriaL1.Morph.SpeedBooster.ScrewAttack.PowerBomb.ETank(2)),
+        };
+
+        #endregion
+
+        #region Crateria Central
+
+        protected override List<Case> PowerBombCrateriaSurface => new() {
+            CaseWith(x => x.CardCrateriaL1.SpeedBooster),
+            CaseWith(x => x.CardCrateriaL1.SpaceJump),
+            CaseWith(x => x.CardCrateriaL1.Morph.Bombs),
+        };
+
+        protected override List<Case> Bombs => new() {
+            CaseWith(x => x.CardCrateriaBoss.Morph.Bombs),
+            CaseWith(x => x.CardCrateriaBoss.Morph.PowerBomb),
+        };
+
+        #endregion
+
+        #region Crateria East
+
+        protected override List<Case> CrateriaEast => new() {
+            CaseWith(x => x.CardCrateriaL2.Super),
+            CaseWith(x => x.CardCrateriaL2.Flute.Ice),
+            CaseWith(x => x.CardCrateriaL2.Flute.HiJump),
+            CaseWith(x => x.CardCrateriaL2.Flute.SpaceJump),
+            CaseWith(x => x.CardCrateriaL2.Glove.Lamp.Ice),
+            CaseWith(x => x.CardCrateriaL2.Glove.Lamp.HiJump),
+            CaseWith(x => x.CardCrateriaL2.Glove.Lamp.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super.CardMaridiaL2.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super.CardMaridiaBoss.SpeedBooster.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super.CardMaridiaBoss.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super.CardMaridiaBoss.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super.CardMaridiaL2.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super.CardMaridiaBoss.SpeedBooster.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super.CardMaridiaBoss.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super.CardMaridiaBoss.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super.CardMaridiaL2.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super.CardMaridiaBoss.SpeedBooster.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super.CardMaridiaBoss.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super.CardMaridiaBoss.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Super.CardMaridiaL2.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Super.CardMaridiaL2.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Super.CardMaridiaBoss.SpeedBooster.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Super.CardMaridiaBoss.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.Super.CardMaridiaBoss.Bombs),
+            CaseWith(x => x.Morph.PowerBomb.Super.Gravity),
+        };
+
+        protected override List<Case> MissileOutsideWreckedShipBottom => new() {
+            CaseWith(x => x.Morph.SpeedBooster),
+            CaseWith(x => x.Morph.Grapple),
+            CaseWith(x => x.Morph.SpaceJump),
+            CaseWith(x => x.Morph.Gravity.Bombs),
+            CaseWith(x => x.Morph.Gravity.HiJump),
+            CaseWith(x => x.Morph.Super.PowerBomb.Gravity),
+            CaseWith(x => x.Morph.Super.MoonPearl.Flippers.Gravity.Sword.Cape.Lamp.KeyCT(2).ScrewAttack.CardMaridiaL2),
+            CaseWith(x => x.Morph.Super.MoonPearl.Flippers.Gravity.MasterSword.Lamp.KeyCT(2).ScrewAttack.CardMaridiaL2),
+            CaseWith(x => x.Morph.Super.MoonPearl.Flippers.Gravity.Hammer.Glove.ScrewAttack.CardMaridiaL2),
+            CaseWith(x => x.Morph.Super.MoonPearl.Flippers.Gravity.Mitt.ScrewAttack.CardMaridiaL2),
+        };
+
+        protected override List<Case> MissilesOutsideWreckedShipTopHalf => new() {
+            CaseWith(x => x.Super.CardCrateriaL2.SpeedBooster.CardWreckedShipBoss.Morph.Bombs),
+            CaseWith(x => x.Super.CardCrateriaL2.SpeedBooster.CardWreckedShipBoss.Morph.PowerBomb),
+            CaseWith(x => x.Super.CardCrateriaL2.Grapple.CardWreckedShipBoss.Morph.Bombs),
+            CaseWith(x => x.Super.CardCrateriaL2.Grapple.CardWreckedShipBoss.Morph.PowerBomb),
+            CaseWith(x => x.Super.CardCrateriaL2.SpaceJump.CardWreckedShipBoss.Morph.Bombs),
+            CaseWith(x => x.Super.CardCrateriaL2.SpaceJump.CardWreckedShipBoss.Morph.PowerBomb),
+            CaseWith(x => x.Super.CardCrateriaL2.Gravity.Morph.Bombs.CardWreckedShipBoss),
+            CaseWith(x => x.Super.Morph.PowerBomb.Gravity.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.Bombs.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Bombs.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.Bombs.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Bombs.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.Bombs.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.Bombs.CardMaridiaL2.CardWreckedShipBoss),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.Bombs.CardWreckedShipBoss),
+        };
+
+        #endregion
+
+        #region Wrecked Ship
+
+        protected override List<Case> WreckedShip => new() {
+            CaseWith(x => x.Super.CardCrateriaL2.SpeedBooster),
+            CaseWith(x => x.Super.CardCrateriaL2.Grapple),
+            CaseWith(x => x.Super.CardCrateriaL2.SpaceJump),
+            CaseWith(x => x.Super.CardCrateriaL2.Gravity.Morph.Bombs),
+            CaseWith(x => x.Super.CardCrateriaL2.Gravity.HiJump),
+            CaseWith(x => x.Super.Morph.PowerBomb.Gravity),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Bombs.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).ScrewAttack.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.SpeedBooster.HiJump),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.SpaceJump),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Bombs.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).ScrewAttack.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.SpeedBooster.HiJump),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.SpaceJump),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Bombs.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.ScrewAttack.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.SpeedBooster.HiJump),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.SpaceJump),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.Bombs),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.Bombs.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.ScrewAttack.CardMaridiaL2),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.SpeedBooster.HiJump),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.SpaceJump),
+            CaseWith(x => x.Super.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.Bombs),
+        };
+
+        protected override List<Case> ReserveTankWreckedShip => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.SpeedBooster.Grapple),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.SpeedBooster.SpaceJump),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.SpeedBooster.Varia.ETank(2)),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.SpeedBooster.ETank(3)),
+        };
+
+        protected override List<Case> MissileGravitySuit => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.CardWreckedShipL1.Grapple),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.CardWreckedShipL1.SpaceJump),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.CardWreckedShipL1.Varia.ETank(2)),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.CardWreckedShipL1.ETank(3)),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.Grapple),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.SpaceJump),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.Varia.ETank(2)),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.ETank(3)),
+        };
+
+        protected override List<Case> MissileWreckedShipTop => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb),
+        };
+
+        protected override List<Case> EnergyTankWreckedShip => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.HiJump),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.SpaceJump),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.SpeedBooster),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.Gravity),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.HiJump),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.SpaceJump),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.SpeedBooster),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.Gravity),
+        };
+
+        protected override List<Case> SuperMissileWreckedShipLeft => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb),
+        };
+
+        protected override List<Case> SuperMissileWreckedShipRight => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb),
+        };
+
+        protected override List<Case> GravitySuit => new() {
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.CardWreckedShipL1.Grapple),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.CardWreckedShipL1.SpaceJump),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.CardWreckedShipL1.Varia.ETank(2)),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.Bombs.CardWreckedShipL1.ETank(3)),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.Grapple),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.SpaceJump),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.Varia.ETank(2)),
+            CaseWith(x => x.CardWreckedShipBoss.Morph.PowerBomb.CardWreckedShipL1.ETank(3)),
+        };
+
+        #endregion
+
+        #region Brinstar Blue
+
+        protected override List<Case> MissileBlueBrinstarMiddle => new() {
+            CaseWith(x => x.CardBrinstarL1.Morph),
+        };
+        
+        protected override List<Case> EnergyTankBrinstarCeiling => new() {
+            CaseWith(x => x.CardBrinstarL1.SpaceJump),
+            CaseWith(x => x.CardBrinstarL1.Morph.Bombs),
+            CaseWith(x => x.CardBrinstarL1.HiJump),
+            CaseWith(x => x.CardBrinstarL1.SpeedBooster),
+            CaseWith(x => x.CardBrinstarL1.Ice),
+        };
+        
+        protected override List<Case> MissileBlueBrinstarBillyMays => new() {
+            CaseWith(x => x.CardBrinstarL1.Morph.PowerBomb),
+        };
+
+
+        #endregion
+
+        #region Brinstar Green
+
+        protected override List<Case> PowerBombGreenBrinstarBottom => new() {
+            CaseWith(x => x.CardBrinstarL2.Morph.PowerBomb),
+        };
+        
+        protected override List<Case> EnergyTankEtecoons => new() {
+            CaseWith(x => x.CardBrinstarL2.Morph.PowerBomb),
+        };
+        
+        protected override List<Case> SuperMissileGreenBrinstarBottom => new() {
+            CaseWith(x => x.CardBrinstarL2.Morph.PowerBomb.Super),
+        };
+
+        #endregion
+
+        #region Brinstar Pink
+
+        protected override List<Case> SuperMissilePinkBrinstar => new() {
+            CaseWith(x => x.CardBrinstarBoss.Morph.Bombs.Super),
+            CaseWith(x => x.CardBrinstarBoss.Morph.PowerBomb.Super),
+        };
+
+        protected override List<Case> EnergyTankBrinstarGate => new() {
+            CaseWith(x => x.CardBrinstarL2.Morph.PowerBomb.Wave.ETank(1)),
+        };
+
+        #endregion
+
+        #region Brinstar Kraid
+
+        protected override List<Case> EnergyTankKraid => new() {
+            CaseWith(x => x.CardBrinstarBoss),
+        };
+        protected override List<Case> VariaSuit => new() {
+            CaseWith(x => x.CardBrinstarBoss),
+        };
+
+        #endregion
+
+        #region Maridia Outer
+
+        protected override List<Case> MaridiaOuter => new() {
+            CaseWith(x => x.Gravity.Morph.PowerBomb.Super),
+            CaseWith(x => x.Gravity.Flute.Morph.PowerBomb),
+            CaseWith(x => x.Gravity.Glove.Lamp.Morph.PowerBomb),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.ScrewAttack),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL1.CardMaridiaL2.ScrewAttack),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Hammer.Glove.CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Hammer.Glove.CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Hammer.Glove.CardMaridiaL1.CardMaridiaL2.ScrewAttack),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Mitt.CardMaridiaL1.CardMaridiaL2.Bombs),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Mitt.CardMaridiaL1.CardMaridiaL2.PowerBomb),
+            CaseWith(x => x.Gravity.MoonPearl.Flippers.Morph.Mitt.CardMaridiaL1.CardMaridiaL2.ScrewAttack),
+        };
+
+        #endregion
+
+        #region Maridia Inner
+
+        protected override List<Case> YellowMaridiaWateringHole => new() {
+            CaseWith(x => x.CardMaridiaL1.Morph.Bombs),
+            CaseWith(x => x.CardMaridiaL1.Morph.PowerBomb),
+        };
+        protected override List<Case> MissileYellowMaridiaFalseWall => new() {
+            CaseWith(x => x.CardMaridiaL1.Morph.Bombs),
+            CaseWith(x => x.CardMaridiaL1.Morph.PowerBomb),
+        };
+
+        protected override List<Case> PlasmaBeam => new() {
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster.CardMaridiaBoss.Gravity.HiJump.ScrewAttack),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster.CardMaridiaBoss.Gravity.HiJump.Plasma),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster.CardMaridiaBoss.Gravity.SpaceJump.ScrewAttack),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster.CardMaridiaBoss.Gravity.SpaceJump.Plasma),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster.CardMaridiaBoss.Gravity.Morph.Bombs.ScrewAttack),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster.CardMaridiaBoss.Gravity.Morph.Bombs.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.SpeedBooster.HiJump.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.SpeedBooster.HiJump.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.SpaceJump.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.SpaceJump.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.Bombs.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.Bombs.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.SpeedBooster.HiJump.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.SpeedBooster.HiJump.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.SpaceJump.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.SpaceJump.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.Bombs.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.Bombs.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.SpeedBooster.HiJump.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.SpeedBooster.HiJump.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.SpaceJump.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.SpaceJump.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.Bombs.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.Bombs.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.SpeedBooster.HiJump.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.SpeedBooster.HiJump.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.SpaceJump.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.SpaceJump.Plasma),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.Bombs.ScrewAttack),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.Bombs.Plasma),
+        };
+
+        protected override List<Case> LeftMaridiaSandPitRoom => new() {
+            CaseWith(x => x.CardMaridiaL1.SpaceJump.Super.Morph.PowerBomb),
+            CaseWith(x => x.CardMaridiaL1.Morph.Bombs.Super),
+            CaseWith(x => x.CardMaridiaL1.SpeedBooster.Super.Morph.PowerBomb),
+            CaseWith(x => x.CardMaridiaL1.Grapple.Super.Morph.PowerBomb),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super.Bombs),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super.PowerBomb),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super.Bombs),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super.PowerBomb),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super.Bombs),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super.PowerBomb),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Mitt.Super.Bombs),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Mitt.Super.PowerBomb),
+        };
+
+        protected override List<Case> MissileRightMaridiaSandPitRoom => RightMaridiaSandPitRoom;
+        protected override List<Case> PowerBombRightMaridiaSandPitRoom => RightMaridiaSandPitRoom;
+
+        List<Case> RightMaridiaSandPitRoom => new() {
+            CaseWith(x => x.CardMaridiaL1.SpaceJump.Super),
+            CaseWith(x => x.CardMaridiaL1.Morph.Bombs.Super),
+            CaseWith(x => x.CardMaridiaL1.SpeedBooster.Super),
+            CaseWith(x => x.CardMaridiaL1.Grapple.Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.Super),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Mitt.Super),
+        };
+
+        protected override List<Case> PinkMaridia => new() {
+            CaseWith(x => x.CardMaridiaL1.SpeedBooster),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).SpeedBooster),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).SpeedBooster),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.SpeedBooster),
+            CaseWith(x => x.CardMaridiaL2.MoonPearl.Flippers.Gravity.Morph.Mitt.SpeedBooster),
+        };
+
+        protected override List<Case> MissileDraygon => new() {
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt),
+        };
+
+        protected override List<Case> EnergyTankBotwoon => new() {
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaL2),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaL2),
+        };
+
+        protected override List<Case> SpaceJump => new() {
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster.CardMaridiaBoss.Gravity.HiJump),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster.CardMaridiaBoss.Gravity.SpaceJump),
+            CaseWith(x => x.CardMaridiaL1.CardMaridiaL2.SpeedBooster.CardMaridiaBoss.Gravity.Morph.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.SpeedBooster.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Sword.Cape.Lamp.KeyCT(2).CardMaridiaBoss.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.SpeedBooster.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.MasterSword.Lamp.KeyCT(2).CardMaridiaBoss.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.SpeedBooster.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Hammer.Glove.CardMaridiaBoss.Bombs),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.SpeedBooster.HiJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.SpaceJump),
+            CaseWith(x => x.MoonPearl.Flippers.Gravity.Morph.Mitt.CardMaridiaBoss.Bombs),
+        };
+
+        #endregion
+
+        #region Norfair Upper West
+
+        // MisileLavaRoom is unchanged by virtue of Space, IBJ, HiJump, Speed already
+        // satisfying crossing Cathedral which in turn shortcuts UN East access
+
+        protected override List<Case> IceBeam => new() {
+            CaseWith(x => x.CardNorfairL1.Morph.Bombs.Varia.SpeedBooster),
+            CaseWith(x => x.CardNorfairL1.Morph.PowerBomb.Varia.SpeedBooster),
+        };
+
+        protected override List<Case> MissileBelowIceBeam => new() {
+            CaseWith(x => x.CardNorfairL1.Morph.PowerBomb.Varia.SpeedBooster),
+        };
+
+        #endregion
+
+        #region Norfair Upper East
+
+        protected override List<Case> NorfairUpperEast => new() {
+            CaseWith(x => x.Morph.Bombs.Super.Varia.CardNorfairL2),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.HiJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.CardNorfairL2.HiJump),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Varia.CardNorfairL2),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Varia.Wave.PowerBomb),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.HiJump),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.SpeedBooster),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.HiJump),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.SpeedBooster),
+        };
+
+        protected override List<Case> ReserveTankNorfair => new() {
+            CaseWith(x => x.CardNorfairL2.Morph.SpaceJump),
+            CaseWith(x => x.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.CardNorfairL2.Morph.Grapple.SpeedBooster),
+            CaseWith(x => x.CardNorfairL2.Morph.Grapple.PowerBomb),
+            CaseWith(x => x.CardNorfairL2.Morph.HiJump),
+            CaseWith(x => x.CardNorfairL2.Morph.Ice),
+        };
+        protected override List<Case> MissileNorfairReserveTank => new() {
+            CaseWith(x => x.CardNorfairL2.Morph.SpaceJump),
+            CaseWith(x => x.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.CardNorfairL2.Morph.Grapple.SpeedBooster),
+            CaseWith(x => x.CardNorfairL2.Morph.Grapple.PowerBomb),
+            CaseWith(x => x.CardNorfairL2.Morph.HiJump),
+            CaseWith(x => x.CardNorfairL2.Morph.Ice),
+        };
+
+        protected override List<Case> MissileBubbleNorfairGreenDoor => new() {
+            CaseWith(x => x.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.CardNorfairL2.Grapple.Morph.SpeedBooster),
+            CaseWith(x => x.CardNorfairL2.Grapple.Morph.PowerBomb),
+            CaseWith(x => x.CardNorfairL2.HiJump),
+            CaseWith(x => x.CardNorfairL2.Ice),
+        };
+
+        protected override List<Case> MissileBubbleNorfair => new() {
+            CaseWith(x => x.CardNorfairL2),
+        };
+
+        protected override List<Case> MissileSpeedBooster => new() {
+            CaseWith(x => x.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.CardNorfairL2.Morph.SpeedBooster),
+            CaseWith(x => x.CardNorfairL2.Morph.PowerBomb),
+            CaseWith(x => x.CardNorfairL2.HiJump),
+            CaseWith(x => x.CardNorfairL2.Ice),
+        };
+        protected override List<Case> SpeedBooster => new() {
+            CaseWith(x => x.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.CardNorfairL2.Morph.SpeedBooster),
+            CaseWith(x => x.CardNorfairL2.Morph.PowerBomb),
+            CaseWith(x => x.CardNorfairL2.HiJump),
+            CaseWith(x => x.CardNorfairL2.Ice),
+        };
+
+        protected override List<Case> MissileWaveBeam => new() {
+            CaseWith(x => x.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.CardNorfairL2.Morph.Bombs),
+            CaseWith(x => x.CardNorfairL2.Morph.SpeedBooster),
+            CaseWith(x => x.CardNorfairL2.Morph.PowerBomb),
+            CaseWith(x => x.CardNorfairL2.HiJump),
+            CaseWith(x => x.CardNorfairL2.Ice),
+            CaseWith(x => x.SpeedBooster.Wave.Morph.Super),
+        };
+
+        protected override List<Case> WaveBeam => new() {
+            CaseWith(x => x.Morph.CardNorfairL2.SpaceJump),
+            CaseWith(x => x.Morph.CardNorfairL2.Bombs),
+            CaseWith(x => x.Morph.CardNorfairL2.SpeedBooster),
+            CaseWith(x => x.Morph.CardNorfairL2.PowerBomb),
+            CaseWith(x => x.Morph.CardNorfairL2.HiJump),
+            CaseWith(x => x.Morph.CardNorfairL2.Ice),
+            CaseWith(x => x.Morph.SpeedBooster.Wave.Super),
+        };
+
+        #endregion
+
+        #region Norfair Upper Crocomire
+
+        protected override List<Case> NorfairUpperCrocomire => new() {
+            CaseWith(x => x.Morph.Bombs.Super.Varia.CardNorfairL2.Wave),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.SpaceJump.Wave),
+            CaseWith(x => x.Morph.PowerBomb.Super.Varia.CardNorfairL2.HiJump.Wave),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.CardNorfairL2.SpaceJump.Gravity.Wave),
+            CaseWith(x => x.ScrewAttack.Super.Morph.Varia.CardNorfairL2.HiJump.Gravity.Wave),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Varia.CardNorfairL1.PowerBomb),
+            CaseWith(x => x.SpeedBooster.Super.Morph.Varia.Wave),
+            CaseWith(x => x.Flute.Varia.CardNorfairL1.Morph.PowerBomb.SpeedBooster),
+            CaseWith(x => x.Flute.Varia.SpeedBooster.Wave),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.SpaceJump.Morph.PowerBomb.Wave),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.SpaceJump.Gravity.Morph.Wave),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.Morph.Bombs.Wave),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.HiJump.Morph.PowerBomb.Wave),
+            CaseWith(x => x.Flute.Varia.Missile.CardNorfairL2.HiJump.Gravity.Morph.Wave),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.SpaceJump.Gravity.Morph.Wave),
+            CaseWith(x => x.Flute.Varia.Super.CardNorfairL2.HiJump.Gravity.Morph.Wave),
+            CaseWith(x => x.Glove.Lamp.Varia.CardNorfairL1.Morph.PowerBomb.SpeedBooster),
+            CaseWith(x => x.Glove.Lamp.Varia.SpeedBooster.Wave),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.SpaceJump.Morph.PowerBomb.Wave),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.SpaceJump.Gravity.Morph.Wave),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.Morph.Bombs.Wave),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.HiJump.Morph.PowerBomb.Wave),
+            CaseWith(x => x.Glove.Lamp.Varia.Missile.CardNorfairL2.HiJump.Gravity.Morph.Wave),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.SpaceJump.Gravity.Morph.Wave),
+            CaseWith(x => x.Glove.Lamp.Varia.Super.CardNorfairL2.HiJump.Gravity.Morph.Wave),
+            CaseWith(x => x.Varia.Flute.Mitt.ScrewAttack.SpaceJump.Super.Gravity.Wave.CardNorfairL2),
+            CaseWith(x => x.Varia.Flute.Mitt.ScrewAttack.SpaceJump.Super.Gravity.Wave.Morph),
+        };
+
+        protected override List<Case> EnergyTankCrocomire => new() {
+            CaseWith(x => x.CardNorfairBoss.ETank(1)),
+            CaseWith(x => x.CardNorfairBoss.SpaceJump),
+            CaseWith(x => x.CardNorfairBoss.Grapple),
+        };
+
+        protected override List<Case> PowerBombCrocomire => new() {
+            CaseWith(x => x.CardNorfairBoss.SpaceJump),
+            CaseWith(x => x.CardNorfairBoss.Morph.Bombs),
+            CaseWith(x => x.CardNorfairBoss.HiJump),
+            CaseWith(x => x.CardNorfairBoss.Grapple),
+        };
+
+        protected override List<Case> MissileBelowCrocomire => new() {
+            CaseWith(x => x.CardNorfairBoss.Morph),
+        };
+
+        protected override List<Case> MissileGrapplingBeam => new() {
+            CaseWith(x => x.CardNorfairBoss.Morph.SpaceJump),
+            CaseWith(x => x.CardNorfairBoss.Morph.Bombs),
+            CaseWith(x => x.CardNorfairBoss.Morph.SpeedBooster.PowerBomb),
+        };
+
+        protected override List<Case> GrapplingBeam => new() {
+            CaseWith(x => x.CardNorfairBoss.Morph.SpaceJump),
+            CaseWith(x => x.CardNorfairBoss.Morph.Bombs),
+            CaseWith(x => x.CardNorfairBoss.Morph.SpeedBooster.PowerBomb),
+        };
+
+        #endregion
+
+        #region Norfair Lower West
+
+        protected override List<Case> NorfairLowerWest => new() {
+            CaseWith(x => x.Varia.Morph.PowerBomb.Super.CardNorfairL2.SpaceJump.Gravity),
+            CaseWith(x => x.Varia.SpeedBooster.Super.Morph.Wave.PowerBomb.SpaceJump.Gravity),
+            CaseWith(x => x.Varia.Flute.Mitt.Morph.Bombs),
+            CaseWith(x => x.Varia.Flute.Mitt.Morph.PowerBomb),
+            CaseWith(x => x.Varia.Flute.Mitt.ScrewAttack),
+        };
+
+        protected override List<Case> MissileMickeyMouseRoom => new() {
+            CaseWith(x => x.Morph.Super.SpaceJump.PowerBomb),
+            CaseWith(x => x.Morph.Super.Bombs.PowerBomb.CardLowerNorfairL1.CardNorfairL2),
+            CaseWith(x => x.Morph.Super.Bombs.PowerBomb.Gravity.CardNorfairL2),
+            CaseWith(x => x.Morph.Super.Bombs.PowerBomb.Gravity.Wave.Grapple),
+        };
+
+        #endregion
+
+        #region Norfair Lower East
+
+        protected override List<Case> NorfairLowerEast => new() {
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Morph.PowerBomb.Super.CardNorfairL2.SpaceJump.Gravity),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.SpeedBooster.Super.Morph.Wave.PowerBomb.SpaceJump.Gravity),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.Mitt.Morph.Bombs.Super.PowerBomb),
+            CaseWith(x => x.Varia.CardLowerNorfairL1.Flute.Mitt.Morph.PowerBomb.Super.SpaceJump),
+        };
+
+        protected override List<Case> MissileLowerNorfairAboveFireFleaRoom => new() {
+            CaseWith(x => x.Morph.CardNorfairL2),
+            CaseWith(x => x.Morph.Gravity.Wave.Grapple),
+            CaseWith(x => x.Morph.Gravity.Wave.SpaceJump),
+        };
+        protected override List<Case> PowerBombLowerNorfairAboveFireFleaRoom => new() {
+            CaseWith(x => x.Morph.CardNorfairL2),
+            CaseWith(x => x.Morph.Gravity.Wave.Grapple),
+            CaseWith(x => x.Morph.Gravity.Wave.SpaceJump),
+        };
+
+        protected override List<Case> PowerBombPowerBombsOfShame => new() {
+            CaseWith(x => x.Morph.CardNorfairL2.PowerBomb),
+            CaseWith(x => x.Morph.Gravity.Wave.Grapple.PowerBomb),
+            CaseWith(x => x.Morph.Gravity.Wave.SpaceJump.PowerBomb),
+        };
+
+        protected override List<Case> MissileLowerNorfairNearWaveBeam => new() {
+            CaseWith(x => x.Morph.CardNorfairL2),
+            CaseWith(x => x.Morph.Gravity.Wave.Grapple),
+            CaseWith(x => x.Morph.Gravity.Wave.SpaceJump),
+        };
+
+        protected override List<Case> EnergyTankRidley => new() {
+            CaseWith(x => x.Morph.CardNorfairL2.CardLowerNorfairBoss.PowerBomb.Super),
+            CaseWith(x => x.Morph.Gravity.Wave.Grapple.CardLowerNorfairBoss.PowerBomb.Super),
+            CaseWith(x => x.Morph.Gravity.Wave.SpaceJump.CardLowerNorfairBoss.PowerBomb.Super),
+        };
+
+        protected override List<Case> EnergyTankFirefleas => new() {
+            CaseWith(x => x.Morph.CardNorfairL2),
+            CaseWith(x => x.Morph.Gravity.Wave.Grapple),
+            CaseWith(x => x.Morph.Gravity.Wave.SpaceJump),
+        };
+
+        #endregion
+
+        #region Light World North West
+
+        protected override List<Case> GraveyardLedge => new() {
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> KingsTomb => new() {
+            CaseWith(x => x.Boots.Mitt),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Boots.Mirror.MoonPearl.Hammer.Glove),
+        };
+
+        #endregion
+
+        #region Light World South
+
+        protected override List<Case> SouthOfGrove => new() {
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Mirror.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Mirror.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.Mirror.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> CheckerboardCave => new() {
+            CaseWith(x => x.Mirror.Flute.Mitt),
+            CaseWith(x => x.Mirror.CardNorfairL2.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Glove),
+            CaseWith(x => x.Mirror.SpeedBooster.Wave.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Glove),
+        };
+
+        protected override List<Case> BombosTablet => new() {
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.Book.MasterSword.Mirror.MoonPearl.Mitt),
+        };
+
+        protected override List<Case> LakeHyliaIsland => new() {
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Hammer.Glove),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.Mitt),
+            CaseWith(x => x.Flippers.MoonPearl.Mirror.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster),
+        };
+
+        #endregion
+
+        #region Dark World North West
+
+        protected override List<Case> DarkWorldNorthWest => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        #endregion
+
+        #region Dark World North East
+
+        protected override List<Case> DarkWorldNorthEast => new() {
+            CaseWith(x => x.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers),
+        };
+
+        protected override List<Case> PyramidFairy => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers.Mirror),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove.Mirror),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers.Mirror),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove.Mirror),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt.Mirror.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Mitt.Mirror.MasterSword.Lamp.KeyCT(2)),
+        };
+
+        #endregion
+
+        #region Dark World South
+
+        protected override List<Case> DarkWorldSouth => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        #endregion
+
+        #region Dark World Mire
+
+        protected override List<Case> DarkWorldMire => new() {
+            CaseWith(x => x.Flute.Mitt),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb),
+            CaseWith(x => x.SpeedBooster.Wave.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb),
+        };
+
+        #endregion
+
+        #region Desert Palace
+
+        protected override List<Case> DesertPalace => new() {
+            CaseWith(x => x.Book),
+            CaseWith(x => x.Mirror.Mitt.Flute),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror),
+            CaseWith(x => x.SpeedBooster.Wave.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror),
+        };
+
+        protected override List<Case> DesertPalaceLanmolas => new() {
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Firerod),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Lamp.Sword),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Lamp.Hammer),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Lamp.Bow),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Lamp.Icerod),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Lamp.Byrna),
+            CaseWith(x => x.Glove.BigKeyDP.KeyDP.Lamp.Somaria),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Firerod),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Sword),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Hammer),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Bow),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Icerod),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Byrna),
+            CaseWith(x => x.CardNorfairL2.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Somaria),
+            CaseWith(x => x.SpeedBooster.Wave.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Firerod),
+            CaseWith(x => x.SpeedBooster.Wave.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Sword),
+            CaseWith(x => x.SpeedBooster.Wave.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Hammer),
+            CaseWith(x => x.SpeedBooster.Wave.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Bow),
+            CaseWith(x => x.SpeedBooster.Wave.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Icerod),
+            CaseWith(x => x.SpeedBooster.Wave.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Byrna),
+            CaseWith(x => x.SpeedBooster.Wave.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb.Mirror.BigKeyDP.KeyDP.Lamp.Somaria),
+        };
+
+        #endregion
+
+        #region Palace of Darkness
+
+        protected override List<Case> PalaceOfDarkness => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2)),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt.Flippers),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers),
+        };
+
+        protected override List<Case> PalaceOfDarknessBigKeyChest => new() {
+            CaseWith(x => x.Has.KeyPD.KeyPD(1)),
+            CaseWith(x => x.KeyPD(6)),
+        };
+
+        protected override List<Case> PalaceOfDarknessCompassChest => new() {
+            CaseWith(x => x.KeyPD(4)),
+        };
+
+        protected override List<Case> PalaceOfDarknessHarmlessHellway => new() {
+            CaseWith(x => x.Has.KeyPD.KeyPD(4)),
+            CaseWith(x => x.KeyPD(6)),
+        };
+
+        protected override List<Case> PalaceOfDarknessDarkBasement => new() {
+            CaseWith(x => x.Lamp.KeyPD(4)),
+        };
+
+        protected override List<Case> PalaceOfDarknessDarkMaze => new() {
+            CaseWith(x => x.Lamp.KeyPD(6)),
+        };
+
+        protected override List<Case> PalaceOfDarknessBigChest => new() {
+            CaseWith(x => x.BigKeyPD.Lamp.KeyPD(6)),
+        };
+
+        #endregion
+
+        #region Swamp Palace
+
+        protected override List<Case> SwampPalace => new() {
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Sword.Cape.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Sword.Cape.Lamp.KeyCT(2).Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.MasterSword.Lamp.KeyCT(2).Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.MasterSword.Lamp.KeyCT(2).Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Hammer),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Hookshot),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mirror.Flippers.Mitt),
+        };
+
+        #endregion
+
+        #region Skull Woods
+
+        protected override List<Case> SkullWoods => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        #endregion
+
+        #region Thieves' Town
+
+        protected override List<Case> ThievesTown => new() {
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.Sword.Cape.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Flippers),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Glove),
+            CaseWith(x => x.MoonPearl.MasterSword.Lamp.KeyCT(2).Hookshot.Hammer),
+            CaseWith(x => x.MoonPearl.CardMaridiaL1.CardMaridiaL2.Morph.PowerBomb.Super.Gravity.SpeedBooster.Flippers.Hookshot),
+            CaseWith(x => x.MoonPearl.Hammer.Glove),
+            CaseWith(x => x.MoonPearl.Mitt),
+        };
+
+        #endregion
+
+        #region Misery Mire
+
+        protected override List<Case> MiseryMire => new() {
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.Flute.Mitt),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.CardNorfairL2.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Boots.SpeedBooster.Wave.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.Flute.Mitt),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.CardNorfairL2.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb),
+            CaseWith(x => x.Ether.Sword.MoonPearl.Hookshot.SpeedBooster.Wave.Varia.Super.Gravity.SpaceJump.Morph.PowerBomb),
+        };
+
+        #endregion
+
+        #region Turtle Rock
+
+        protected override List<Case> TurtleRockBigKeyChest => new() {
+            CaseWith(x => x.Has.BigKeyTR.KeyTR(2)),
+            CaseWith(x => x.Has.KeyTR.KeyTR(3)),
+            CaseWith(x => x.KeyTR(4)),
+        };
+
+        #endregion
+
+    }
+
+}

--- a/Randomizer.SMZ3.Tests/Randomizer.SMZ3.Tests.csproj
+++ b/Randomizer.SMZ3.Tests/Randomizer.SMZ3.Tests.csproj
@@ -12,6 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="SharpYaml" Version="1.6.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Randomizer.SMZ3\Randomizer.SMZ3.csproj" />

--- a/Randomizer.SMZ3.Tests/Randomizer.SMZ3.Tests.csproj
+++ b/Randomizer.SMZ3.Tests/Randomizer.SMZ3.Tests.csproj
@@ -5,14 +5,12 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="nunit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="SharpYaml" Version="1.6.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Randomizer.SMZ3\Randomizer.SMZ3.csproj" />

--- a/Randomizer.SMZ3/Item.cs
+++ b/Randomizer.SMZ3/Item.cs
@@ -832,11 +832,12 @@ namespace Randomizer.SMZ3 {
         public static bool CanAccessMiseryMirePortal(this Progression items, Config config) {
             return config.SMLogic switch {
                 Normal =>
-                    (items.CardNorfairL2 || (items.SpeedBooster && items.Wave)) && items.Varia && items.Super && (items.Gravity && items.SpaceJump) && items.CanUsePowerBombs(),
+                    (items.CardNorfairL2 || items.SpeedBooster && items.Wave) && items.Varia && items.Super &&
+                        items.Gravity && items.SpaceJump && items.CanUsePowerBombs(),
                 _ =>
                     (items.CardNorfairL2 || items.SpeedBooster) && items.Varia && items.Super && (
                         items.CanFly() || items.HiJump || items.SpeedBooster || items.CanSpringBallJump() || items.Ice
-                   ) && (items.Gravity || items.HiJump) && items.CanUsePowerBombs()
+                    ) && (items.Gravity || items.HiJump) && items.CanUsePowerBombs()
              };
         }
 

--- a/Randomizer.SMZ3/Location.cs
+++ b/Randomizer.SMZ3/Location.cs
@@ -82,6 +82,10 @@ namespace Randomizer.SMZ3 {
             Item = oldItem;
             return fillable;
         }
+
+        // For logic unit tests
+        internal bool CanAccess(Progression items) => canAccess(items);
+
     }
 
     static class LocationsExtensions {

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Blue.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Blue.cs
@@ -18,7 +18,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
                     _ => new Requirement(items => items.CardBrinstarL1 && items.Morph)
                 }),
                 new Location(this, 29, 0x8F879E, LocationType.Hidden, "Energy Tank, Brinstar Ceiling", Logic switch {
-                    Normal => items => items.CardBrinstarL1 && (items.CanFly() || items.HiJump ||items.SpeedBooster || items.Ice),
+                    Normal => items => items.CardBrinstarL1 && (items.CanFly() || items.HiJump || items.SpeedBooster || items.Ice),
                     _ => new Requirement(items => items.CardBrinstarL1)
                 }),
                 new Location(this, 34, 0x8F8802, LocationType.Chozo, "Missile (blue Brinstar bottom)", Logic switch {

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Pink.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/Pink.cs
@@ -50,7 +50,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar {
                 _ =>
                     items.CanOpenRedDoors() && (items.CanDestroyBombWalls() || items.SpeedBooster) ||
                     items.CanUsePowerBombs() ||
-                    items.CanAccessNorfairUpperPortal() && items.Morph && (items.CanOpenRedDoors() || items.Wave) &&
+                    items.CanAccessNorfairUpperPortal() && items.Morph && (items.Missile || items.Super || items.Wave /* Blue Gate */) &&
                         (items.Ice || items.HiJump || items.CanSpringBallJump() || items.CanFly())
             };
         }

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/East.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/East.cs
@@ -14,14 +14,15 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria {
                     Normal => items => items.Morph && (
                         items.SpeedBooster || items.Grapple || items.SpaceJump ||
                         items.Gravity && (items.CanIbj() || items.HiJump) ||
-                        World.CanEnter("Wrecked Ship", items)),
+                        World.CanEnter("Wrecked Ship", items)
+                    ),
                     _ => new Requirement(items => items.Morph)
                 }),
                 new Location(this, 2, 0x8F81EE, LocationType.Hidden, "Missile (outside Wrecked Ship top)", Logic switch {
-                    _ => new Requirement(items => World.CanEnter("Wrecked Ship", items) && (!Config.Keysanity || items.CardWreckedShipBoss) && items.CanPassBombPassages())
+                    _ => new Requirement(items => World.CanEnter("Wrecked Ship", items) && items.CardWreckedShipBoss && items.CanPassBombPassages())
                 }),
                 new Location(this, 3, 0x8F81F4, LocationType.Visible, "Missile (outside Wrecked Ship middle)", Logic switch {
-                    _ => new Requirement(items => World.CanEnter("Wrecked Ship", items) && (!Config.Keysanity || items.CardWreckedShipBoss) && items.CanPassBombPassages())
+                    _ => new Requirement(items => World.CanEnter("Wrecked Ship", items) && items.CardWreckedShipBoss && items.CanPassBombPassages())
                 }),
                 new Location(this, 4, 0x8F8248, LocationType.Visible, "Missile (Crateria moat)", Logic switch {
                     _ => new Requirement(items => true)
@@ -37,22 +38,22 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria {
                     /* UN Portal -> Red Tower -> Moat */
                     (Config.Keysanity ? items.CardCrateriaL2 : items.CanUsePowerBombs()) && items.CanAccessNorfairUpperPortal() &&
                         (items.Ice || items.HiJump || items.SpaceJump) ||
-                    /*Through Maridia From Portal*/
+                    /* Through Maridia From Portal */
                     items.CanAccessMaridiaPortal(World) && items.Gravity && items.Super && (
                         /* Oasis -> Forgotten Highway */
                         items.CardMaridiaL2 && items.CanDestroyBombWalls() ||
                         /* Draygon -> Cactus Alley -> Forgotten Highway */
-                        World.GetLocation("Space Jump").Available(items)) ||
+                        World.GetLocation("Space Jump").Available(items)
+                    ) ||
                     /*Through Maridia from Pipe*/
-                    items.CanUsePowerBombs() && items.Super && items.Gravity
-                    ,
+                    items.CanUsePowerBombs() && items.Super && items.Gravity,
                 _ =>
                     /* Ship -> Moat */
                     (Config.Keysanity ? items.CardCrateriaL2 : items.CanUsePowerBombs()) && items.Super ||
                     /* UN Portal -> Red Tower -> Moat */
                     (Config.Keysanity ? items.CardCrateriaL2 : items.CanUsePowerBombs()) && items.CanAccessNorfairUpperPortal() &&
                         (items.Ice || items.HiJump || items.CanFly() || items.CanSpringBallJump()) ||
-                    /*Through Maridia From Portal*/
+                    /* Through Maridia From Portal */
                     items.CanAccessMaridiaPortal(World) && (
                         /* Oasis -> Forgotten Highway */
                         items.CardMaridiaL2 && items.Super && (
@@ -60,10 +61,13 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria {
                             items.Gravity && items.CanDestroyBombWalls()
                         ) ||
                         /* Draygon -> Cactus Alley -> Forgotten Highway */
-                        items.Gravity && World.GetLocation("Space Jump").Available(items)) ||
-                    /*Through Maridia from Pipe*/
-                    items.CanUsePowerBombs() && items.Super && (items.Gravity || items.HiJump && (items.Ice || items.CanSpringBallJump()) 
-                                                                && items.Grapple && items.CardMaridiaL1)
+                        items.Gravity && World.GetLocation("Space Jump").Available(items)
+                    ) ||
+                    /* Through Maridia from Pipe */
+                    items.CanUsePowerBombs() && items.Super && (
+                        items.Gravity ||
+                        items.HiJump && (items.Ice || items.CanSpringBallJump()) && items.Grapple && items.CardMaridiaL1
+                    ),
             };
         }
 

--- a/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
@@ -36,12 +36,12 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
                 new Location(this, 144, 0x8FC5DD, LocationType.Visible, "Missile (left Maridia sand pit room)", Logic switch {
                     Normal => items => CanReachAqueduct(items) && items.Super && items.CanPassBombPassages(),
                     _ => new Requirement(items => CanReachAqueduct(items) && items.Super &&
-                        (items.HiJump && (items.SpaceJump || items.CanSpringBallJump()) || items.Gravity))
+                        (items.Gravity || items.HiJump && (items.SpaceJump || items.CanSpringBallJump())))
                 }),
                 new Location(this, 145, 0x8FC5E3, LocationType.Chozo, "Reserve Tank, Maridia", Logic switch {
                     Normal => items => CanReachAqueduct(items) && items.Super && items.CanPassBombPassages(),
                     _ => new Requirement(items => CanReachAqueduct(items) && items.Super &&
-                        (items.HiJump && (items.SpaceJump || items.CanSpringBallJump()) || items.Gravity))
+                        (items.Gravity || items.HiJump && (items.SpaceJump || items.CanSpringBallJump())))
                 }),
                 new Location(this, 146, 0x8FC5EB, LocationType.Visible, "Missile (right Maridia sand pit room)", Logic switch {
                     Normal => new Requirement(items => CanReachAqueduct(items) && items.Super),
@@ -49,7 +49,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
                 }),
                 new Location(this, 147, 0x8FC5F1, LocationType.Visible, "Power Bomb (right Maridia sand pit room)", Logic switch {
                     Normal => new Requirement(items => CanReachAqueduct(items) && items.Super),
-                    _ => items => CanReachAqueduct(items) && items.Super && (items.HiJump && items.CanSpringBallJump() || items.Gravity)
+                    _ => items => CanReachAqueduct(items) && items.Super && (items.Gravity || items.HiJump && items.CanSpringBallJump())
                 }),
                 new Location(this, 148, 0x8FC603, LocationType.Visible, "Missile (pink Maridia)", Logic switch {
                     Normal => items => CanReachAqueduct(items) && items.SpeedBooster,

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/East.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/East.cs
@@ -37,14 +37,22 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
 
         bool CanExit(Progression items) {
             return Logic switch {
-                Normal => items.CardNorfairL2 /*Bubble Mountain*/ ||
-                    items.Gravity && items.Wave /* Volcano Room and Blue Gate */ && (items.Grapple || items.SpaceJump /*Spikey Acid Snakes and Croc Escape*/),
-                _ => /*Vanilla LN Escape*/
-                    (items.Morph && (items.CardNorfairL2 /*Bubble Mountain*/ || (items.Missile || items.Super || items.Wave /* Blue Gate */) && 
-                                     (items.SpeedBooster || items.CanFly() || items.Grapple || items.HiJump && 
-                                     (items.CanSpringBallJump() || items.Ice) /*Frog Speedway or Croc Escape*/)) ||
-                    /*Reverse Amphitheater*/
-                     items.HasEnergyReserves(5)),
+                Normal => /* Intended LN Escape */
+                    items.Morph && (
+                        items.CardNorfairL2 /* Bubble Mountain */ ||
+                        items.Gravity && items.Wave /* Volcano Room, Blue Gate */ &&
+                            (items.Grapple || items.SpaceJump) /* Spikey Acid Snakes -> Croc Escape (this shortcuts Frog Speedway) */
+                    ),
+                _ => /* Intended LN Escape */
+                    items.Morph && (
+                        items.CardNorfairL2 /* Bubble Mountain */ ||
+                        (items.Missile || items.Super || items.Wave /* Blue Gate */) && (
+                            items.SpeedBooster || items.CanFly() || items.Grapple ||
+                            items.HiJump && (items.CanSpringBallJump() || items.Ice) /* Frog Speedway / Croc Escape */
+                        )
+                    ) ||
+                    /* Reverse Amphitheater */
+                    items.HasEnergyReserves(5),
             };
         }
 
@@ -61,7 +69,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
                         items.CanAccessNorfairLowerPortal() && items.CanDestroyBombWalls() && items.Super && (items.CanFly() || items.CanSpringBallJump() || items.SpeedBooster)
                     ) &&
                     (items.CanFly() || items.HiJump || items.CanSpringBallJump() || items.Ice && items.Charge) &&
-                    (items.CanPassBombPassages() || items.ScrewAttack && items.SpaceJump)                     
+                    (items.CanPassBombPassages() || items.ScrewAttack && items.SpaceJump)
             };
         }
 

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/West.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/West.cs
@@ -27,21 +27,26 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
                     _ => new Requirement(items => items.CanDestroyBombWalls() && (items.CanAccessNorfairLowerPortal() || items.Varia))
                 }),
                 new Location(this, 73, 0x8F8F30, LocationType.Visible, "Missile (Mickey Mouse room)", Logic switch {
-                    Normal => items => items.CanFly() && items.Morph && items.Super &&
-                        /*Exit to Upper Norfair*/
-                        ((items.CardLowerNorfairL1 || items.Gravity /*Vanilla or Reverse Lava Dive*/) && items.CardNorfairL2 /*Bubble Mountain*/ ||
-                        items.Gravity && items.Wave /* Volcano Room and Blue Gate */ && (items.Grapple || items.SpaceJump) /*Spikey Acid Snakes and Croc Escape*/ ||
-                        /*Exit via GT fight and Portal*/
-                        (items.CanUsePowerBombs() && items.SpaceJump && (items.Super || items.Charge))),
-                    _ => new Requirement(items => 
-                         items.Morph && items.Varia && items.Super && ((items.CanFly() || items.CanSpringBallJump() && items.CanPassBombPassages() ||
-                                         (items.CardNorfairL2 && items.CanUsePowerBombs() && (items.HiJump || items.Gravity) || items.SpeedBooster)
-                                           && (items.HiJump && items.CanUsePowerBombs() || items.Charge && items.Ice)) &&
-                         /*Exit to Upper Norfair*/
-                         (items.CardNorfairL2 || (items.SpeedBooster || items.CanFly() || items.Grapple || items.HiJump &&
-                        (items.CanSpringBallJump() || items.Ice))) ||
-                         /*Return to Portal*/
-                         items.CanUsePowerBombs()))
+                    Normal => items => items.Morph && items.Super &&
+                        /* Climb worst room (from LN East CanEnter) */
+                        items.CanFly() && items.CanUsePowerBombs() && (
+                            /* Exit to Upper Norfair */
+                            (items.CardLowerNorfairL1 || items.Gravity) /* Intended, or Reverse Lava Dive */ && items.CardNorfairL2 /* Bubble Mountain */ ||
+                            items.Gravity && items.Wave /* Volcano Room and Blue Gate */ &&
+                                (items.Grapple || items.SpaceJump) /* Spikey Acid Snakes -> Croc Escape (this shortcuts Frog Speedway) */ ||
+                            /* GT fight -> Portal */
+                            items.CanUsePowerBombs() && items.SpaceJump && (items.Super || items.Charge)
+                        ),
+                    _ => new Requirement(items => items.Varia && items.Morph && items.Super &&
+                        /* Climb worst room (from LN East CanEnter) */
+                        (items.CanFly() || items.HiJump || items.CanSpringBallJump() || items.Ice && items.Charge) &&
+                        (items.CanPassBombPassages() || items.ScrewAttack && items.SpaceJump) && (
+                            /* Exit to Upper Norfair */
+                            items.CardNorfairL2 || items.SpeedBooster || items.CanFly() || items.Grapple ||
+                            items.HiJump && (items.CanSpringBallJump() || items.Ice) ||
+                            /* Portal (with GGG) */
+                            items.CanUsePowerBombs()
+                        )),
                 }),
             };
         }

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/West.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairLower/West.cs
@@ -14,16 +14,17 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
                     Normal => items => items.CanUsePowerBombs() && items.SpaceJump && items.Super,
                     _ => new Requirement(items => items.CanUsePowerBombs() && items.SpaceJump && items.Varia && (
                         items.HiJump || items.Gravity ||
-                        items.CanAccessNorfairLowerPortal() && (items.CanFly() || items.CanSpringBallJump() || items.SpeedBooster) && items.Super))
+                        items.CanAccessNorfairLowerPortal() && (items.CanFly() || items.CanSpringBallJump() || items.SpeedBooster) && items.Super
+                    )),
                 }),
                 new Location(this, 71, 0x8F8E74, LocationType.Hidden, "Super Missile (Gold Torizo)", Logic switch {
                     Normal => items => items.CanDestroyBombWalls() && (items.Super || items.Charge) &&
-                        (items.CanAccessNorfairLowerPortal() || items.SpaceJump && items.CanUsePowerBombs()),
+                        (items.CanAccessNorfairLowerPortal() || items.CanUsePowerBombs() && items.SpaceJump),
                     _ => new Requirement(items => items.CanDestroyBombWalls() && items.Varia && (items.Super || items.Charge))
                 }),
                 new Location(this, 79, 0x8F9110, LocationType.Chozo, "Screw Attack", Logic switch {
-                    Normal => items => items.CanDestroyBombWalls() && (items.SpaceJump && items.CanUsePowerBombs() || items.CanAccessNorfairLowerPortal()),
-                    _ => new Requirement(items => items.CanDestroyBombWalls() && (items.Varia || items.CanAccessNorfairLowerPortal()))
+                    Normal => items => items.CanDestroyBombWalls() && (items.CanAccessNorfairLowerPortal() || items.CanUsePowerBombs() && items.SpaceJump),
+                    _ => new Requirement(items => items.CanDestroyBombWalls() && (items.CanAccessNorfairLowerPortal() || items.Varia))
                 }),
                 new Location(this, 73, 0x8F8F30, LocationType.Visible, "Missile (Mickey Mouse room)", Logic switch {
                     Normal => items => items.CanFly() && items.Morph && items.Super &&
@@ -63,7 +64,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairLower {
                         /* Trivial case, Bubble Mountain access */
                         items.CardNorfairL2 ||
                         /* Frog Speedway -> UN Farming Room gate */
-                        items.SpeedBooster && (items.Missile || items.Super || items.Wave) /* Blue Gate */
+                        items.SpeedBooster && (items.Missile || items.Super || items.Wave /* Blue Gate */)
                     ) ||
                     items.CanAccessNorfairLowerPortal() && items.CanDestroyBombWalls()
             };

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/Crocomire.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/Crocomire.cs
@@ -16,8 +16,10 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
                 }),
                 new Location(this, 54, 0x8F8BC0, LocationType.Visible, "Missile (above Crocomire)", Logic switch {
                     Normal => items => items.CanFly() || items.Grapple || items.HiJump && items.SpeedBooster,
-                    _ => new Requirement(items => (items.CanFly() || items.Grapple || items.HiJump &&
-                        (items.SpeedBooster || items.CanSpringBallJump() || items.Varia && items.Ice)) && items.CanHellRun())
+                    _ => new Requirement(items => (
+                            items.CanFly() || items.Grapple ||
+                            items.HiJump && (items.SpeedBooster || items.CanSpringBallJump() || items.Varia && items.Ice)
+                        ) && items.CanHellRun()),
                 }),
                 new Location(this, 57, 0x8F8C04, LocationType.Visible, "Power Bomb (Crocomire)", Logic switch {
                     Normal => items => CanAccessCrocomire(items) && (items.CanFly() || items.HiJump || items.Grapple),
@@ -32,8 +34,9 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
                 }),
                 new Location(this, 60, 0x8F8C36, LocationType.Chozo, "Grappling Beam", Logic switch {
                     Normal => items => CanAccessCrocomire(items) && items.Morph && (items.CanFly() || items.SpeedBooster && items.CanUsePowerBombs()),
-                    _ => new Requirement(items => CanAccessCrocomire(items) && (items.SpaceJump || items.Morph || items.Grapple ||
-                        items.HiJump && items.SpeedBooster))
+                    _ => new Requirement(items => CanAccessCrocomire(items) && (
+                        items.SpaceJump || items.Morph || items.Grapple || items.HiJump && items.SpeedBooster
+                    )),
                 }),
             };
         }

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/Crocomire.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/Crocomire.cs
@@ -50,8 +50,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
                 Normal => (
                         (items.CanDestroyBombWalls() || items.SpeedBooster) && items.Super && items.Morph ||
                         items.CanAccessNorfairUpperPortal()
-                    ) &&
-                    items.Varia && (
+                    ) && items.Varia && (
                         /* Ice Beam -> Croc Speedway */
                         (Config.Keysanity ? items.CardNorfairL1 : items.Super) && items.CanUsePowerBombs() && items.SpeedBooster ||
                         /* Frog Speedway */
@@ -60,11 +59,10 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
                         items.CanOpenRedDoors() && (Config.Keysanity ? items.CardNorfairL2 : items.Super) &&
                             (items.CanFly() || items.HiJump || items.SpeedBooster) &&
                             (items.CanPassBombPassages() || items.Gravity && items.Morph) && items.Wave
-                        ||
-                        /* Reverse Lava Dive */
-                        items.CanAccessNorfairLowerPortal() && items.ScrewAttack && items.SpaceJump && items.Super && 
-                        items.Gravity && items.Wave && (items.CardNorfairL2 || items.Morph)
-                      ),
+                    ) ||
+                    /* Reverse Lava Dive */
+                    items.Varia && items.CanAccessNorfairLowerPortal() && items.ScrewAttack && items.SpaceJump && items.Super &&
+                        items.Gravity && items.Wave && (items.CardNorfairL2 || items.Morph),
                 _ => (
                         (items.CanDestroyBombWalls() || items.SpeedBooster) && items.Super && items.Morph ||
                         items.CanAccessNorfairUpperPortal()
@@ -74,15 +72,15 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
                             items.SpeedBooster && (items.HasEnergyReserves(3) || items.Varia) ||
                         /* Frog Speedway */
                         items.SpeedBooster && (items.HasEnergyReserves(2) || items.Varia) &&
-                            (items.Missile || items.Super || items.Wave) /* Blue Gate */ ||
+                            (items.Missile || items.Super || items.Wave /* Blue Gate */) ||
                         /* Cathedral -> through the floor or Vulcano */
                         items.CanHellRun() && items.CanOpenRedDoors() && (Config.Keysanity ? items.CardNorfairL2 : items.Super) &&
                             (items.CanFly() || items.HiJump || items.SpeedBooster || items.CanSpringBallJump() || items.Varia && items.Ice) &&
                             (items.CanPassBombPassages() || items.Varia && items.Morph) &&
-                            (items.Missile || items.Super || items.Wave) /* Blue Gate */
-                        ) ||
-                        /* Reverse Lava Dive */
-                        items.CanAccessNorfairLowerPortal() && items.ScrewAttack && items.SpaceJump && items.Varia && items.Super && 
+                            (items.Missile || items.Super || items.Wave /* Blue Gate */)
+                    ) ||
+                    /* Reverse Lava Dive */
+                    items.Varia && items.CanAccessNorfairLowerPortal() && items.ScrewAttack && items.SpaceJump && items.Super && 
                         items.HasEnergyReserves(2) && (items.CardNorfairL2 || items.Morph)
             };
         }

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/East.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/East.cs
@@ -89,7 +89,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
                         items.CanOpenRedDoors() && (Config.Keysanity ? items.CardNorfairL2 : items.Super) &&
                             (items.CanFly() || items.HiJump || items.SpeedBooster) ||
                         /* Frog Speedway */
-                        items.SpeedBooster && (items.CardNorfairL2 || items.Wave) && items.CanUsePowerBombs()
+                        items.SpeedBooster && (items.CardNorfairL2 || items.Wave /* Blue Gate */) && items.CanUsePowerBombs()
                     ),
                 _ => (
                         (items.CanDestroyBombWalls() || items.SpeedBooster) && items.Super && items.Morph ||
@@ -102,7 +102,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
                             items.CanSpringBallJump() || items.Varia && items.Ice
                         ) ||
                         /* Frog Speedway */
-                        items.SpeedBooster && (items.CardNorfairL2 || items.Missile || items.Super || items.Wave) && items.CanUsePowerBombs()
+                        items.SpeedBooster && (items.CardNorfairL2 || items.Missile || items.Super || items.Wave /* Blue Gate */) && items.CanUsePowerBombs()
                     ),
             };
         }

--- a/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/West.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/NorfairUpper/West.cs
@@ -31,9 +31,9 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.NorfairUpper {
                     Normal => items => (config.Keysanity ? items.CardNorfairL1 : items.Super) && items.CanUsePowerBombs() && items.Varia && items.SpeedBooster,
                     _ => new Requirement(items =>
                         (config.Keysanity ? items.CardNorfairL1 : items.Super) && items.CanUsePowerBombs() && (items.Varia || items.HasEnergyReserves(3)) ||
-                        (items.Missile || items.Super || items.Wave) /* Blue Gate */ && items.Varia && items.SpeedBooster &&
-                        /* Access to Croc's room to get spark */
-                        (config.Keysanity ? items.CardNorfairBoss : items.Super) && items.CardNorfairL1)
+                        (items.Missile || items.Super || items.Wave /* Blue Gate */) && items.Varia && items.SpeedBooster &&
+                            /* Access to Croc's room to get spark */
+                            (config.Keysanity ? items.CardNorfairBoss : items.Super) && items.CardNorfairL1)
                 }),
                 new Location(this, 53, 0x8F8BAC, LocationType.Chozo, "Hi-Jump Boots", Logic switch {
                     _ => new Requirement(items => items.CanOpenRedDoors() && items.CanPassBombPassages())

--- a/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
@@ -16,7 +16,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid {
                     _ => new Requirement(items => items.CanPassBombPassages())
                 }),
                 new Location(this, 129, 0x8FC2E9, LocationType.Chozo, "Reserve Tank, Wrecked Ship", Logic switch {
-                    Normal => items => CanUnlockShip(items) && items.CardWreckedShipL1 && items.SpeedBooster && items.CanUsePowerBombs() &&
+                    Normal => items => CanUnlockShip(items) && items.CardWreckedShipL1 && items.CanUsePowerBombs() && items.SpeedBooster &&
                         (items.Grapple || items.SpaceJump || items.Varia && items.HasEnergyReserves(2) || items.HasEnergyReserves(3)),
                     _ => new Requirement(items => CanUnlockShip(items) && items.CardWreckedShipL1 && items.CanUsePowerBombs() && items.SpeedBooster &&
                         (items.Varia || items.HasEnergyReserves(2)))
@@ -31,8 +31,10 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid {
                 new Location(this, 132, 0x8FC337, LocationType.Visible, "Energy Tank, Wrecked Ship", Logic switch {
                     Normal => items => CanUnlockShip(items) &&
                         (items.HiJump || items.SpaceJump || items.SpeedBooster || items.Gravity),
-                    _ => new Requirement(items => CanUnlockShip(items) && (items.Bombs || items.PowerBomb || items.CanSpringBallJump() ||
-                        items.HiJump || items.SpaceJump || items.SpeedBooster || items.Gravity))
+                    _ => new Requirement(items => CanUnlockShip(items) && (
+                        items.Morph && (items.Bombs || items.PowerBomb) /* "OnceBJ" */ || items.CanSpringBallJump() ||
+                        items.HiJump || items.SpaceJump || items.SpeedBooster || items.Gravity
+                    )),
                 }),
                 new Location(this, 133, 0x8FC357, LocationType.Visible, "Super Missile (Wrecked Ship left)",
                     items => CanUnlockShip(items)),

--- a/Randomizer.SMZ3/Regions/Zelda/GanonsTower.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/GanonsTower.cs
@@ -122,8 +122,10 @@ namespace Randomizer.SMZ3.Regions.Zelda {
         }
 
         private bool BigKeyRoom(Progression items) {
-            return items.KeyGT >= 3 && CanBeatArmos(items) 
-                && (items.Hammer && items.Hookshot || items.Firerod && items.Somaria);
+            return items.KeyGT >= 3 && (
+                items.Hammer && items.Hookshot ||
+                items.Firerod && items.Somaria
+            ) && CanBeatArmos(items);
         }
 
         private bool TowerAscend(Progression items) {
@@ -142,7 +144,7 @@ namespace Randomizer.SMZ3.Regions.Zelda {
 
         public override bool CanEnter(Progression items) {
             return items.MoonPearl && World.CanEnter("Dark World Death Mountain East", items) &&
-                World.CanAquireAll(items, new[] { CrystalBlue, CrystalRed, GoldenFourBoss });
+                World.CanAquireAll(items, CrystalBlue, CrystalRed, GoldenFourBoss);
         }
 
         public override bool CanFill(Item item, Progression items) {

--- a/Randomizer.SMZ3/Regions/Zelda/PalaceOfDarkness.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/PalaceOfDarkness.cs
@@ -17,7 +17,7 @@ namespace Randomizer.SMZ3.Regions.Zelda {
                 new Location(this, 256+121, 0x1EA5B, LocationType.Regular, "Palace of Darkness - Shooter Room"),
                 new Location(this, 256+122, 0x1EA37, LocationType.Regular, "Palace of Darkness - Big Key Chest",
                     items => items.KeyPD >= (GetLocation("Palace of Darkness - Big Key Chest").ItemIs(KeyPD, World) ? 1 :
-                        (items.Hammer && items.Bow && items.Lamp) || config.Keysanity ? 6 : 5))
+                        config.Keysanity || items.Hammer && items.Bow && items.Lamp ? 6 : 5))
                     .AlwaysAllow((item, items) => item.Is(KeyPD, World) && items.KeyPD >= 5),
                 new Location(this, 256+123, 0x1EA49, LocationType.Regular, "Palace of Darkness - Stalfos Basement",
                     items => items.KeyPD >= 1 || items.Bow && items.Hammer),
@@ -28,22 +28,22 @@ namespace Randomizer.SMZ3.Regions.Zelda {
                 new Location(this, 256+126, 0x1EA52, LocationType.Regular, "Palace of Darkness - Map Chest",
                     items => items.Bow),
                 new Location(this, 256+127, 0x1EA43, LocationType.Regular, "Palace of Darkness - Compass Chest",
-                    items => items.KeyPD >= ((items.Hammer && items.Bow && items.Lamp) || config.Keysanity ? 4 : 3)),
+                    items => items.KeyPD >= (config.Keysanity || items.Hammer && items.Bow && items.Lamp ? 4 : 3)),
                 new Location(this, 256+128, 0x1EA46, LocationType.Regular, "Palace of Darkness - Harmless Hellway",
                     items => items.KeyPD >= (GetLocation("Palace of Darkness - Harmless Hellway").ItemIs(KeyPD, World) ?
-                        (items.Hammer && items.Bow && items.Lamp) || config.Keysanity ? 4 : 3 :
-                        (items.Hammer && items.Bow && items.Lamp) || config.Keysanity ? 6 : 5))
+                        config.Keysanity || items.Hammer && items.Bow && items.Lamp ? 4 : 3 :
+                        config.Keysanity || items.Hammer && items.Bow && items.Lamp ? 6 : 5))
                     .AlwaysAllow((item, items) => item.Is(KeyPD, World) && items.KeyPD >= 5),
                 new Location(this, 256+129, 0x1EA4C, LocationType.Regular, "Palace of Darkness - Dark Basement - Left",
-                    items => items.Lamp && items.KeyPD >= ((items.Hammer && items.Bow) || config.Keysanity ? 4 : 3)),
+                    items => items.Lamp && items.KeyPD >= (config.Keysanity || items.Hammer && items.Bow ? 4 : 3)),
                 new Location(this, 256+130, 0x1EA4F, LocationType.Regular, "Palace of Darkness - Dark Basement - Right",
-                    items => items.Lamp && items.KeyPD >= ((items.Hammer && items.Bow) || config.Keysanity ? 4 : 3)),
+                    items => items.Lamp && items.KeyPD >= (config.Keysanity || items.Hammer && items.Bow ? 4 : 3)),
                 new Location(this, 256+131, 0x1EA55, LocationType.Regular, "Palace of Darkness - Dark Maze - Top",
-                    items => items.Lamp && items.KeyPD >= ((items.Hammer && items.Bow) || config.Keysanity ? 6 : 5)),
+                    items => items.Lamp && items.KeyPD >= (config.Keysanity || items.Hammer && items.Bow ? 6 : 5)),
                 new Location(this, 256+132, 0x1EA58, LocationType.Regular, "Palace of Darkness - Dark Maze - Bottom",
-                    items => items.Lamp && items.KeyPD >= ((items.Hammer && items.Bow) || config.Keysanity ? 6 : 5)),
+                    items => items.Lamp && items.KeyPD >= (config.Keysanity || items.Hammer && items.Bow ? 6 : 5)),
                 new Location(this, 256+133, 0x1EA40, LocationType.Regular, "Palace of Darkness - Big Chest",
-                    items => items.BigKeyPD && items.Lamp && items.KeyPD >= ((items.Hammer && items.Bow) || config.Keysanity ? 6 : 5)),
+                    items => items.BigKeyPD && items.Lamp && items.KeyPD >= (config.Keysanity || items.Hammer && items.Bow ? 6 : 5)),
                 new Location(this, 256+134, 0x308153, LocationType.Regular, "Palace of Darkness - Helmasaur King",
                     items => items.Lamp && items.Hammer && items.Bow && items.BigKeyPD && items.KeyPD >= 6),
             };

--- a/Randomizer.SMZ3/World.cs
+++ b/Randomizer.SMZ3/World.cs
@@ -92,7 +92,8 @@ namespace Randomizer.SMZ3 {
         }
 
         public bool CanAquire(Progression items, RewardType reward) {
-                return Regions.OfType<IReward>().First(x => reward == x.Reward).CanComplete(items);
+            // For the purpose of logic unit tests, if no region has the reward then CanAquire is satisfied
+            return Regions.OfType<IReward>().FirstOrDefault(x => reward == x.Reward)?.CanComplete(items) ?? true;
         }
 
         public bool CanAquireAll(Progression items, params RewardType[] rewards) {


### PR DESCRIPTION
As the commit mentions, having cases of progression that covers both the region's CanEnter and the logic of the location made for an O(n^2) situation that the NUnit framework handled very poorly. I had to stretch into the internals of `Location` so I could test the location logic expressions separate from the region. With that change the tests run somewhat quickly.

This PR contains some important logic changes that need as many eyes as possible for verification. @TarThoron 