### PR TITLE
Comprehensive seed data in ROM

### DIFF
--- a/Randomizer.SMZ3/Patch.cs
+++ b/Randomizer.SMZ3/Patch.cs
@@ -587,11 +587,15 @@ namespace Randomizer.SMZ3 {
                 (Randomizer.version.Major << 4) |
                 (Randomizer.version.Minor << 0);
 
+            var extraConfigField =
+                ((int)myWorld.Config.SwordLocation << 14) |
+                ((int)myWorld.Config.MorphLocation << 12) |
+                ((int)myWorld.Config.Goal << 8);
+
             patches.Add((Snes(0x80FF50), UshortBytes(myWorld.Id)));
             patches.Add((Snes(0x80FF52), UshortBytes(configField)));
             patches.Add((Snes(0x80FF54), UintBytes(seed)));
-            /* Reserve the rest of the space for future use */
-            patches.Add((Snes(0x80FF58), Repeat<byte>(0x00, 8).ToArray()));
+            patches.Add((Snes(0x80FF58), UshortBytes(extraConfigField)));
             patches.Add((Snes(0x80FF60), AsAscii(seedGuid)));
             patches.Add((Snes(0x80FF80), AsAscii(myWorld.Guid)));
         }


### PR DESCRIPTION
I used the reserved space at `$80FF58` for some previously unwritten seed data. It's another `UShort` bitfield mapped as follows, starting from the MSB:
* `SwordLocation` filling 2 bits
* `MorphLocation` filling 2 bits
* `Goal` filling 4 bits (2 bits seems a bit small here)
* 8 reserved bits for any future nuance in the seed data

Since only 8 bits are occupied, this could just be a `Byte`. However, I suggest that all extra future seed data be written to the ROM. This way, there isn't any data loss from a filename change, and all of the data is contained in one place. I argue that this is significant for any theoretical tool that deals with SMZ3 ROMs.