### PR TITLE
Move World Setup out of Filler

### DIFF
--- a/Randomizer.SMZ3/Filler.cs
+++ b/Randomizer.SMZ3/Filler.cs
@@ -14,10 +14,6 @@ namespace Randomizer.SMZ3 {
             Worlds = worlds;
             Config = config;
             Rnd = rnd;
-
-            foreach (var world in worlds) {
-                world.Setup(Rnd);
-            }
         }
 
         public void Fill() {

--- a/Randomizer.SMZ3/Randomizer.cs
+++ b/Randomizer.SMZ3/Randomizer.cs
@@ -59,17 +59,21 @@ namespace Randomizer.SMZ3 {
                 randoRnd = new Random(randoRnd.Next());
             }
 
-            if (config.GameMode == GameMode.Normal) {
-                worlds.Add(new World(config, "Player", 0, new HexGuid()));
-            }
-            else {
-                int players = options.ContainsKey("players") ? int.Parse(options["players"]) : 1;
-                for (int p = 0; p < players; p++) {
+            int players = options.ContainsKey("players") ? int.Parse(options["players"]) : 1;
+            for (int p = 0; p < players; p++) {
+                // Get the playername
+                string playername = "Player";
+                if (config.GameMode != GameMode.Normal) {
                     var found = options.TryGetValue($"player-{p}", out var player);
                     if (!found || !alphaNumeric.IsMatch(player))
                         throw new ArgumentException($"Name for player {p + 1} not provided, or contains no alphanumeric characters");
-                    worlds.Add(new World(config, player, p, new HexGuid()));
+                    playername = player;
                 }
+
+                // Setup worlds while here
+                var new_world = new World(config, playername, p, new HexGuid());
+                new_world.Setup(randoRnd);
+                worlds.Add(new_world);
             }
 
             var filler = new Filler(worlds, config, randoRnd);


### PR DESCRIPTION

Feel free to ignore this request, just a suggestion.

It became clear as part of the new reward code that world setup is inside of the Filler object instantiation. This is a side-effect which means it's not obvious. Moving world setup into Randomizer.cs seems more cleaner/more obvious.

While here, doing a little bit of cleanup on the world creation loop (bifurcate on playername, rather than the entire loop, since the loop has to run at least once anyway).