### PR TITLE
Move World setup out of Filler

### DIFF
--- a/Randomizer.SMZ3/Filler.cs
+++ b/Randomizer.SMZ3/Filler.cs
@@ -18,10 +18,6 @@ namespace Randomizer.SMZ3 {
             Config = config;
             Rnd = rnd;
             CancellationToken = cancellationToken;
-
-            foreach (var world in worlds) {
-                world.Setup(Rnd);
-            }
         }
 
         public void Fill() {

--- a/Randomizer.SMZ3/Randomizer.cs
+++ b/Randomizer.SMZ3/Randomizer.cs
@@ -43,20 +43,22 @@ namespace Randomizer.SMZ3 {
             }
 
             var worlds = new List<World>();
-            if (config.SingleWorld) {
-                worlds.Add(new World(config, "Player", 0, new HexGuid()));
-            }
-            else {
-                var players = options.ContainsKey("players") ? int.Parse(options["players"]) : 1;
-                for (var p = 0; p < players; p++) {
+            var players = options.ContainsKey("players") ? int.Parse(options["players"]) : 1;
+            for (var p = 0; p < players; p++) {
+                string playername = "Player";
+                if (config.MultiWorld) {
                     var found = options.TryGetValue($"player-{p}", out var player);
                     if (!found)
                         throw new ArgumentException($"No name provided for player {p + 1}");
                     if (!legalCharacters.IsMatch(player))
                         throw new ArgumentException($"No alphanumeric characters found in name for player {p + 1}");
-                    player = CleanPlayerName(player);
-                    worlds.Add(new World(config, player, p, new HexGuid()));
+                    playername = CleanPlayerName(player);
                 }
+
+                // Setup the new world while here
+                var new_world = new World(config, playername, p, new HexGuid());
+                new_world.Setup(randoRnd);
+                worlds.Add(new_world);
             }
 
             var filler = new Filler(worlds, config, randoRnd, cancellationToken);


### PR DESCRIPTION
Sorry for last pull request; forgot to update local branch. Rest of the text is the same. The "doesn't merge cleanly" should have been a clue.

Feel free to ignore this request, just a suggestion.

It became clear as part of the new reward code that world setup is inside of the Filler object instantiation. This is a side-effect which means it's not obvious. Moving world setup into Randomizer.cs seems cleaner/more obvious.

While here, doing a little bit of cleanup on the world creation loop (bifurcate on playername, rather than the entire loop, since the loop has to run at least once anyway).