### PR TITLE
Spoiler refactoring and log file improvement

### DIFF
--- a/WebRandomizer/ClientApp/package.json
+++ b/WebRandomizer/ClientApp/package.json
@@ -27,7 +27,8 @@
     "slugid": "^2.0.0",
     "styled-components": "^5.2.1",
     "wasm-loader": "^1.3.0",
-    "xxhashjs": "^0.2.2"
+    "xxhashjs": "^0.2.2",
+    "yaml": "^1.10.2"
   },
   "devDependencies": {
     "ajv": "^6.10.2",

--- a/WebRandomizer/ClientApp/src/generate/Permalink.jsx
+++ b/WebRandomizer/ClientApp/src/generate/Permalink.jsx
@@ -12,6 +12,7 @@ import { adjustHostname } from '../site/domain';
 
 import { decode } from 'slugid';
 
+import { tryParseJson } from '../util';
 import defaults from 'lodash/defaults';
 import attempt from 'lodash/attempt';
 
@@ -174,7 +175,9 @@ export default function Permalink() {
                     </Row>
                 </CardBody>
             </Card>
-            <Spoiler seedData={seed} />
+            {settings && settings.race === 'false' && (
+                <Spoiler seedGuid={seed.guid} />
+            )}
         </>) :
         errorMessage ? <MessageCard error={true} title="Something went wrong :(" msg={errorMessage} /> :
         gameMismatch ? (
@@ -193,12 +196,4 @@ export default function Permalink() {
             </Row>
         </Container>
     );
-}
-
-function tryParseJson(text) {
-    try {
-        return JSON.parse(text);
-    } catch (syntaxerror) {
-        return null;
-    }
 }

--- a/WebRandomizer/ClientApp/src/multiworld/Multiworld.jsx
+++ b/WebRandomizer/ClientApp/src/multiworld/Multiworld.jsx
@@ -21,6 +21,8 @@ import isEmpty from 'lodash/isEmpty';
 import minBy from 'lodash/minBy';
 import maxBy from 'lodash/maxBy';
 
+import { tryParseJson } from '../util';
+
 // Message types to handle from WASM
 const MessageType = {
     ConsoleDisconnected: 0,
@@ -277,6 +279,7 @@ export default function Multiworld() {
     if (state === null) return null;
 
     const { session, clientData, device, status, patch } = state;
+    const { race } = session ? tryParseJson(session.seed.worlds[0].settings) : {};
     const gameMismatch = session && session.seed.game_id !== game.id;
 
     return !gameMismatch ? (
@@ -323,10 +326,10 @@ export default function Multiworld() {
                     </Col>
                 </Row>
             )}
-            {session && session.seed !== null && (
+            {session && race === 'false' && (
                 <Row className="mb-3">
                     <Col>
-                        <Spoiler seedData={{ ...session.seed, spoiler: '[]' }} />
+                        <Spoiler seedGuid={session.seed.guid} />
                     </Col>
                 </Row>
             )}

--- a/WebRandomizer/ClientApp/src/spoiler/Spoiler.jsx
+++ b/WebRandomizer/ClientApp/src/spoiler/Spoiler.jsx
@@ -5,6 +5,8 @@ import { SmallNavLink, StyledTable } from './styled';
 
 import { SearchIcon, DownloadIcon } from './styled';
 
+import { regionOrdering } from './region_ordering';
+
 import YAML from 'yaml';
 import { saveAs } from 'file-saver';
 import { encode } from 'slugid';
@@ -38,7 +40,7 @@ export default function Spoiler({ seedGuid }) {
                 const response = await fetch(`/api/spoiler/${seedGuid}`);
                 const data = await response.json();
                 data.seed.spoiler = filter(tryParseJson(data.seed.spoiler), sphere => !isEmpty(sphere));
-                data.locations = sortBy(data.locations, 'locationId');
+                data.locations = sortBy(data.locations, ({ locationRegion }) => regionOrdering(locationRegion));
                 setSpoiler(data);
             } catch { }
         }
@@ -126,7 +128,7 @@ export default function Spoiler({ seedGuid }) {
     }
 
     function region(compose, locations, worlds, multiworld) {
-        return map(sortGroupBy(locations, 'locationRegion'), ([region, locations]) =>
+        return map(sortGroupBy(locations, 'locationRegion', regionOrdering), ([region, locations]) =>
             compose(region, map(locations, ({ locationName, worldId, itemName, itemWorldId }) => [
                 multiworld ? `${locationName} - ${worlds[worldId].player}` : locationName,
                 multiworld ? `${itemName} - ${worlds[itemWorldId].player}` : itemName,

--- a/WebRandomizer/ClientApp/src/spoiler/Spoiler.jsx
+++ b/WebRandomizer/ClientApp/src/spoiler/Spoiler.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Row, Col, Card, CardHeader, CardBody, Nav, NavItem, NavLink } from 'reactstrap';
 import { InputGroup, InputGroupAddon, InputGroupText, Input, Button } from 'reactstrap';
 
-import { JournalArrowDown } from '../ui/BootstrapIcon';
+import { Search, JournalArrowDown } from '../ui/BootstrapIcon';
 
 import { saveAs } from 'file-saver';
 import { encode } from 'slugid';
@@ -33,6 +33,11 @@ const LocationTable = styled.table.attrs(props => ({
   > tbody > tr {
     border-bottom: 1px solid #e0e0e0;
   }
+`;
+
+const SearchIcon = styled(Search)`
+  width: 1em;
+  height: 1em;
 `;
 
 const DownloadIcon = styled(JournalArrowDown)`
@@ -128,7 +133,7 @@ export default function Spoiler(props) {
                             <Col md="9">
                             <SearchInputGroup>
                                 <InputGroupAddon addonType="prepend">
-                                    <InputGroupText><span role="img" aria-label="search">🔎</span></InputGroupText>
+                                    <InputGroupText><SearchIcon /></InputGroupText>
                                 </InputGroupAddon>
                                 <Input key="searchInput" placeholder="Find a location or item" onChange={updateSearchText} value={searchText} />
                                 </SearchInputGroup>

--- a/WebRandomizer/ClientApp/src/spoiler/Spoiler.jsx
+++ b/WebRandomizer/ClientApp/src/spoiler/Spoiler.jsx
@@ -1,9 +1,9 @@
 ﻿import React, { useState } from 'react';
-import styled from 'styled-components';
-import { Row, Col, Card, CardHeader, CardBody, Nav, NavItem, NavLink } from 'reactstrap';
-import { InputGroup, InputGroupAddon, InputGroupText, Input, Button } from 'reactstrap';
+import { Row, Col, Card, CardHeader, CardBody, Nav, NavItem, Input, Button } from 'reactstrap';
+import InputGroup from '../ui/PrefixInputGroup';
+import { SmallNavLink, LocationTable } from './styled';
 
-import { Search, JournalArrowDown } from '../ui/BootstrapIcon';
+import { SearchIcon, DownloadIcon } from './styled';
 
 import { saveAs } from 'file-saver';
 import { encode } from 'slugid';
@@ -12,38 +12,6 @@ import isEmpty from 'lodash/isEmpty';
 import sortBy from 'lodash/sortBy';
 import uniq from 'lodash/uniq';
 import escapeRegExp from 'lodash/escapeRegExp';
-
-const SmallNavLink = styled(NavLink)`
-  font-size: .87em;
-  font-weight: bold;
-  padding-top: 6px;
-  padding-bottom: 6px;
-  padding-right: 9px;
-  padding-left: 9px;
-`;
-
-const SearchInputGroup = styled(InputGroup)`
-  margin-bottom: 15px;
-`;
-
-const LocationTable = styled.table.attrs(props => ({
-    className: "table table-sm table-borderless"
-}))`
-  margin-bottom: 25px;
-  > tbody > tr {
-    border-bottom: 1px solid #e0e0e0;
-  }
-`;
-
-const SearchIcon = styled(Search)`
-  width: 1em;
-  height: 1em;
-`;
-
-const DownloadIcon = styled(JournalArrowDown)`
-  width: 1em;
-  height: 1em;
-`;
 
 export default function Spoiler(props) {
     const [show, setShow] = useState(false);
@@ -129,22 +97,19 @@ export default function Spoiler(props) {
             {show && (<CardBody>
                 {spoiler
                     ? <div>
-                        <Row>
-                            <Col md="9">
-                            <SearchInputGroup>
-                                <InputGroupAddon addonType="prepend">
-                                    <InputGroupText><SearchIcon /></InputGroupText>
-                                </InputGroupAddon>
+                    <Row>
+                        <Col md="9">
+                            <InputGroup className="mb-3" prefix={<SearchIcon />}>
                                 <Input key="searchInput" placeholder="Find a location or item" onChange={updateSearchText} value={searchText} />
-                                </SearchInputGroup>
-                            </Col>
-                            <Col>
-                                <Button outline color="primary" className="float-right" onClick={downloadSpoiler}><DownloadIcon /> Download</Button>
-                            </Col>
-                        </Row>
-                        <div>
-                            <Nav pills style={{ marginBottom: "10px" }}>
-                                <NavItem>
+                            </InputGroup>
+                        </Col>
+                        <Col>
+                            <Button outline color="primary" className="float-right" onClick={downloadSpoiler}><DownloadIcon /> Download</Button>
+                        </Col>
+                    </Row>
+                    <div>
+                        <Nav pills className="mb-2">
+                            <NavItem>
                                     <SmallNavLink href="#" active={spoilerArea === "playthrough"} onClick={() => setSpoilerArea("playthrough")}>Playthrough</SmallNavLink>
                                 </NavItem>
                                 {props.seedData.gameId === 'smz3' && <NavItem>
@@ -165,7 +130,7 @@ export default function Spoiler(props) {
                                         {playthrough.map((sphere, i) => (
                                             <div key={i}>
                                                 {i < (playthrough.length - 1) || props.seedData.gameId === 'sm' ? <h6>Sphere {i + 1}</h6> : <h6>Prizes and Requirements</h6>}
-                                                <LocationTable>
+                                                <LocationTable className="mb-4">
                                                     <tbody>
                                                         {Object.entries(sphere).map(([location, item], j) => (
                                                             <tr key={j}>
@@ -184,7 +149,7 @@ export default function Spoiler(props) {
                                         <CardBody>
                                             <div>
                                                 <h6>Prizes and Requirements</h6>
-                                                <LocationTable>
+                                                <LocationTable className="mb-4">
                                                     <tbody>
                                                         {Object.entries(playthrough[playthrough.length - 1]).map(([location, item], i) => (
                                                             <tr key={i}>
@@ -202,7 +167,7 @@ export default function Spoiler(props) {
                                         {uniq(sortBy(locations.filter(l => spoilerArea === 'all' || l.locationArea === spoilerArea), l => l.locationRegion).map(l => l.locationRegion)).map((r, i) => (
                                             <div key={i}>
                                                 <h6>{r}</h6>
-                                                <LocationTable>
+                                                <LocationTable className="mb-4">
                                                     <tbody>
                                                     {locations.filter(l => (spoilerArea === 'all' || l.locationArea === spoilerArea) && l.locationRegion === r).map((l, j) => (
                                                         <tr key={j}>

--- a/WebRandomizer/ClientApp/src/spoiler/region_ordering.js
+++ b/WebRandomizer/ClientApp/src/spoiler/region_ordering.js
@@ -1,0 +1,51 @@
+﻿import indexOf from 'lodash/indexOf';
+
+const ordering = [
+    'Light World Death Mountain West',
+    'Light World Death Mountain East',
+    'Light World North West',
+    'Light World North East',
+    'Light World South',
+    'Hyrule Castle',
+    'Dark World Death Mountain West',
+    'Dark World Death Mountain East',
+    'Dark World North West',
+    'Dark World North East',
+    'Dark World South',
+    'Dark World Mire',
+
+    'Castle Tower',
+
+    'Eastern Palace',
+    'Desert Palace',
+    'Tower of Hera',
+    'Palace of Darkness',
+    'Swamp Palace',
+    'Skull Woods',
+    "Thieves' Town",
+    'Ice Palace',
+    'Misery Mire',
+    'Turtle Rock',
+    "Ganon's Tower",
+
+    'Crateria West',
+    'Crateria Central',
+    'Crateria East',
+    'Brinstar Blue',
+    'Brinstar Green',
+    'Brinstar Pink',
+    'Brinstar Red',
+    'Brinstar Kraid',
+    'Wrecked Ship',
+    'Maridia Outer',
+    'Maridia Inner',
+    'Norfair Upper West',
+    'Norfair Upper East',
+    'Norfair Upper Crocomire',
+    'Norfair Lower West',
+    'Norfair Lower East',
+];
+
+export function regionOrdering(name) {
+    return indexOf(ordering, name);
+}

--- a/WebRandomizer/ClientApp/src/spoiler/styled.js
+++ b/WebRandomizer/ClientApp/src/spoiler/styled.js
@@ -1,0 +1,31 @@
+import { NavLink } from 'reactstrap';
+import styled from 'styled-components';
+
+import { Search, JournalArrowDown } from '../ui/BootstrapIcon';
+
+export const SmallNavLink = styled(NavLink)`
+  font-size: .87em;
+  font-weight: bold;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  padding-right: 9px;
+  padding-left: 9px;
+`;
+
+export const LocationTable = styled.table.attrs({
+    className: "table table-sm table-borderless"
+})`
+  > tbody > tr {
+    border-bottom: 1px solid #E0E0E0;
+  }
+`;
+
+export const SearchIcon = styled(Search)`
+  width: 1em;
+  height: 1em;
+`;
+
+export const DownloadIcon = styled(JournalArrowDown)`
+  width: 1em;
+  height: 1em;
+`;

--- a/WebRandomizer/ClientApp/src/spoiler/styled.js
+++ b/WebRandomizer/ClientApp/src/spoiler/styled.js
@@ -12,11 +12,12 @@ export const SmallNavLink = styled(NavLink)`
   padding-left: 9px;
 `;
 
-export const LocationTable = styled.table.attrs({
+export const StyledTable = styled.table.attrs({
     className: "table table-sm table-borderless"
 })`
   > tbody > tr {
     border-bottom: 1px solid #E0E0E0;
+    > td:first-child { width: 60% }
   }
 `;
 

--- a/WebRandomizer/ClientApp/src/ui/BootstrapIcon.jsx
+++ b/WebRandomizer/ClientApp/src/ui/BootstrapIcon.jsx
@@ -21,6 +21,13 @@ export const DashSquareFill = (props) => (
     </svg>
 );
 
+/* https://icons.getbootstrap.com/icons/search/ */
+export const Search = (props) => (
+    <svg {...props} viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z" />
+    </svg>
+);
+
 /* https://icons.getbootstrap.com/icons/journal-arrow-down/ */
 export const JournalArrowDown = (props) => (
     <svg {...props} viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">

--- a/WebRandomizer/ClientApp/src/util.js
+++ b/WebRandomizer/ClientApp/src/util.js
@@ -1,3 +1,7 @@
+import sortBy from 'lodash/sortBy';
+import groupBy from 'lodash/groupBy';
+import toPairs from 'lodash/toPairs';
+
 export async function readAsArrayBuffer(blob) {
     const fileReader = new FileReader();
     return new Promise((resolve, reject) => {
@@ -20,4 +24,9 @@ export function tryParseJson(text) {
     } catch (syntaxerror) {
         return null;
     }
+}
+
+export function sortGroupBy(collection, iteratee) {
+    const groups = groupBy(collection, iteratee);
+    return sortBy(toPairs(groups), ([key]) => key);
 }

--- a/WebRandomizer/ClientApp/src/util.js
+++ b/WebRandomizer/ClientApp/src/util.js
@@ -1,6 +1,7 @@
 import sortBy from 'lodash/sortBy';
 import groupBy from 'lodash/groupBy';
 import toPairs from 'lodash/toPairs';
+import { iteratee } from 'lodash';
 
 export async function readAsArrayBuffer(blob) {
     const fileReader = new FileReader();
@@ -26,7 +27,8 @@ export function tryParseJson(text) {
     }
 }
 
-export function sortGroupBy(collection, iteratee) {
-    const groups = groupBy(collection, iteratee);
-    return sortBy(toPairs(groups), ([key]) => key);
+export function sortGroupBy(collection, grouping, sorting) {
+    sorting = iteratee(sorting);
+    const groups = groupBy(collection, grouping);
+    return sortBy(toPairs(groups), ([key]) => sorting(key));
 }

--- a/WebRandomizer/ClientApp/src/util.js
+++ b/WebRandomizer/ClientApp/src/util.js
@@ -13,3 +13,11 @@ export async function readAsArrayBuffer(blob) {
         fileReader.readAsArrayBuffer(blob);
     });
 }
+
+export function tryParseJson(text) {
+    try {
+        return JSON.parse(text);
+    } catch (syntaxerror) {
+        return null;
+    }
+}


### PR DESCRIPTION
Main highlights:
* Parent components check the race setting flag, either rendering the `Spoiler` or not at all.
* `Spoiler` only takes the seed guid, used to fetch all spoiler data from the spoiler api endpoint.
* Locations are no longer sorted by their id (relying on the ordinal order as received from the api), but instead grouped by a predetermined region order.
* The spoiler log is rendered using the YAML format instead of JSON. It includes a header with the game id, version, seed hash, and a meta section with (for now):
  * SMZ3: Goal, SM Logic, Keysanity, Crystal and Boss Token requirements
  * SM: Goal, Logic