### PR TITLE
Ensure Crab Shaft climbable suitless

### DIFF
--- a/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
+++ b/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/Inner.cs
@@ -13,13 +13,16 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia {
         public Inner(World world, Config config) : base(world, config) {
             Locations = new List<Location> {
                 new Location(this, 140, 0x8FC4AF, LocationType.Visible, "Super Missile (yellow Maridia)", Logic switch {
-                    _ => new Requirement(items => items.CardMaridiaL1 && items.CanPassBombPassages() && CanReachAqueduct(items))
+                    _ => new Requirement(items => items.CardMaridiaL1 && items.CanPassBombPassages() && CanReachAqueduct(items)
+                         && (items.Gravity || items.Ice || items.HiJump && items.SpringBall))
                 }),
                 new Location(this, 141, 0x8FC4B5, LocationType.Visible, "Missile (yellow Maridia super missile)", Logic switch {
-                    _ => new Requirement(items => items.CardMaridiaL1 && items.CanPassBombPassages() && CanReachAqueduct(items))
+                    _ => new Requirement(items => items.CardMaridiaL1 && items.CanPassBombPassages() && CanReachAqueduct(items)
+                         && (items.Gravity || items.Ice || items.HiJump && items.SpringBall))
                 }),
                 new Location(this, 142, 0x8FC533, LocationType.Visible, "Missile (yellow Maridia false wall)", Logic switch {
-                    _ => new Requirement(items => items.CardMaridiaL1 && items.CanPassBombPassages() && CanReachAqueduct(items))
+                    _ => new Requirement(items => items.CardMaridiaL1 && items.CanPassBombPassages() && CanReachAqueduct(items)
+                         && (items.Gravity || items.Ice || items.HiJump && items.SpringBall))
                 }),
                 new Location(this, 143, 0x8FC559, LocationType.Chozo, "Plasma Beam", Logic switch {
                     Normal => items => CanDefeatDraygon(items) && (items.ScrewAttack || items.Plasma) && (items.HiJump || items.CanFly()),


### PR DESCRIPTION
Yellow Maridia has been logically accessible from the portal with just HJB or Spring for suitless movement, which would require Super Metroid Impossible style walljumping up the left side.

This change makes sure you have either Gravity or at least two of HJB, Spring, and Ice. Doesn't need a Logic Switch because Normal always has Gravity.