### PR TITLE
Fix GT Entry token requirement

### DIFF
--- a/Randomizer.SMZ3/Regions/Zelda/GanonsTower.cs
+++ b/Randomizer.SMZ3/Regions/Zelda/GanonsTower.cs
@@ -145,7 +145,7 @@ namespace Randomizer.SMZ3.Regions.Zelda {
         public override bool CanEnter(Progression items) {
             return items.MoonPearl && World.CanEnter("Dark World Death Mountain East", items) &&
                 World.CanAcquireAtLeast(World.TowerCrystals, items, AnyCrystal) &&
-                World.CanAcquireAtLeast(World.TourianBossTokens * (World.TowerCrystals / 7), items, AnyBossToken);
+                World.CanAcquireAtLeast((World.TourianBossTokens * World.TowerCrystals) / 7, items, AnyBossToken);
         }
 
         public override bool CanFill(Item item, Progression items) {


### PR DESCRIPTION
It's been discovered that TO(GT/7) is getting rounded to TO(0) if GT is anything other than 7. This can be fixed by multiplying before dividing, thus (TO*GT)/7.